### PR TITLE
Fix the second output no render

### DIFF
--- a/examples/tinywl/Main.qml
+++ b/examples/tinywl/Main.qml
@@ -104,32 +104,6 @@ Item {
                         anchors.fill: parent
                     }
 
-                    Repeater {
-                        id: re
-                        anchors.fill: parent
-                        clip: false
-
-                        model: ListModel {
-                            Component.onCompleted: {
-                                renderWindow.surfaceModel = this
-                            }
-                        }
-
-                        SurfaceItem {
-                            id: surfaceItem
-                            required property WaylandSurface waylandSurface
-
-                            surface: waylandSurface
-
-                            Component.onCompleted: {
-                                waylandSurface.shell = surfaceItem
-
-                                x = (parent.width - width) / 2
-                                y = (parent.height - height) / 2
-                            }
-                        }
-                    }
-
                     Column {
                         anchors {
                             bottom: parent.bottom
@@ -181,6 +155,30 @@ Item {
                             }
                         }
                     }
+                }
+            }
+        }
+
+        Repeater {
+            anchors.fill: parent
+            clip: false
+
+            model: ListModel {
+                Component.onCompleted: {
+                    if (!renderWindow.surfaceModel)
+                        renderWindow.surfaceModel = this
+                }
+            }
+
+            SurfaceItem {
+                id: surfaceItem
+                required property WaylandSurface waylandSurface
+                property bool positionInitialized: false
+
+                surface: waylandSurface
+
+                Component.onCompleted: {
+                    waylandSurface.shell = surfaceItem
                 }
             }
         }

--- a/src/server/kernel/woutput.cpp
+++ b/src/server/kernel/woutput.cpp
@@ -10,6 +10,8 @@
 #include <qwoutput.h>
 #include <qwoutputlayout.h>
 #include <qwrenderer.h>
+#include <qwswapchain.h>
+#include <qwallocator.h>
 
 extern "C" {
 #define static
@@ -43,7 +45,7 @@ public:
             }
 
             if (event->committed & WLR_OUTPUT_STATE_MODE) {
-                Q_EMIT qq->sizeChanged();
+                Q_EMIT qq->modeChanged();
                 Q_EMIT qq->effectiveSizeChanged();
             }
 
@@ -109,6 +111,18 @@ QWRenderer *WOutput::renderer() const
 {
     W_DC(WOutput);
     return QWRenderer::from(d->handle->handle()->renderer);
+}
+
+QWSwapchain *WOutput::swapchain() const
+{
+    W_DC(WOutput);
+    return QWSwapchain::from(d->handle->handle()->swapchain);
+}
+
+QWAllocator *WOutput::allocator() const
+{
+    W_DC(WOutput);
+    return QWAllocator::from(d->handle->handle()->allocator);
 }
 
 WOutputViewport *WOutput::handle() const

--- a/src/server/kernel/woutput.h
+++ b/src/server/kernel/woutput.h
@@ -19,6 +19,8 @@ QT_END_NAMESPACE
 
 QW_BEGIN_NAMESPACE
 class QWRenderer;
+class QWSwapchain;
+class QWAllocator;
 QW_END_NAMESPACE
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
@@ -62,6 +64,8 @@ public:
     WBackend *backend() const;
     WServer *server() const;
     QW_NAMESPACE::QWRenderer *renderer() const;
+    QW_NAMESPACE::QWSwapchain *swapchain() const;
+    QW_NAMESPACE::QWAllocator *allocator() const;
 
     WOutputViewport *handle() const;
     template<typename DNativeInterface>
@@ -100,7 +104,7 @@ public:
 
 Q_SIGNALS:
     void positionChanged(const QPoint &pos);
-    void sizeChanged();
+    void modeChanged();
     void transformedSizeChanged();
     void effectiveSizeChanged();
     void orientationChanged();

--- a/src/server/platformplugin/qwlrootswindow.h
+++ b/src/server/platformplugin/qwlrootswindow.h
@@ -4,18 +4,27 @@
 #pragma once
 
 #include "wglobal.h"
+#include <qwglobal.h>
 
+#include <QPointer>
 #include <qpa/qplatformwindow.h>
+
+QW_BEGIN_NAMESPACE
+class QWBuffer;
+QW_END_NAMESPACE
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
+class QWlrootsScreen;
 class Q_DECL_HIDDEN QWlrootsOutputWindow : public QPlatformWindow
 {
 public:
     QWlrootsOutputWindow(QWindow *window);
+    ~QWlrootsOutputWindow();
 
     void initialize() override;
 
+    QWlrootsScreen *qwScreen() const;
     QPlatformScreen *screen() const override;
     void setGeometry(const QRect &rect) override;
     QRect geometry() const override;
@@ -23,7 +32,15 @@ public:
     WId winId() const override;
     qreal devicePixelRatio() const override;
 
+    void setBuffer(QW_NAMESPACE::QWBuffer *buffer);
+    QW_NAMESPACE::QWBuffer *buffer() const;
+
+    bool attachRenderer();
+    void detachRenderer();
+
 private:
+    QPointer<QW_NAMESPACE::QWBuffer> renderBuffer;
+    bool bufferAttached = false;
     QMetaObject::Connection onScreenGeometryConnection;
 };
 


### PR DESCRIPTION
Don't attach render to wlr_output, manager the output buffer in waylib, so we can't cache the QQuickRenderTarget for the wlr_buffer in waylib.