### PR TITLE
Don‘t set deprecated flag in qt6

### DIFF
--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -179,8 +179,6 @@ int main(int argc, char *argv[]) {
     WServer::initializeQPA();
     QQuickStyle::setStyle("Material");
 
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QGuiApplication::setAttribute(Qt::AA_UseOpenGLES);
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
     QGuiApplication::setQuitOnLastWindowClosed(false);


### PR DESCRIPTION
 警告：‘Qt::AA_EnableHighDpiScaling’ is deprecated: High-DPI scaling is always enabled. This attribute no longer has any effect.
警告：‘Qt::AA_UseHighDpiPixmaps’ is deprecated: High-DPI pixmaps are always enabled. This attribute no longer has any effect.