### PR TITLE
Optimize multi outputs

### DIFF
--- a/examples/tinywl/Main.qml
+++ b/examples/tinywl/Main.qml
@@ -97,7 +97,7 @@ Item {
 
                     Image {
                         id: background
-                        sourceSize: Qt.size(parent.width, parent.height)
+                        sourceSize: Qt.size(parent.width * waylandOutput.scale, parent.height * waylandOutput.scale)
                         source: "file:///usr/share/backgrounds/deepin/desktop.jpg"
                         fillMode: Image.PreserveAspectCrop
                         asynchronous: true

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -123,12 +123,18 @@ set(HEADERS
     utils/wimagebuffer.h
 )
 
+set(PRIVATE_HEADERS
+    platformplugin/types.h
+)
+
 add_library(${TARGET}
     SHARED
     ${KERNEL_SOURCES}
     ${QTQUICK_SOURCES}
     ${UTILS_SOURCES}
     ${QPA_SOURCES}
+    ${HEADERS}
+    ${PRIVATE_HEADERS}
 )
 
 qt_add_qml_module(${TARGET}
@@ -141,6 +147,7 @@ set_target_properties(${TARGET}
         VERSION ${CMAKE_PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
         PUBLIC_HEADER "${HEADERS}"
+        PRIVATE_HEADER "${PRIVATE_HEADERS}"
 )
 
 set(QT_LIBRAIES

--- a/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/src/server/platformplugin/qwlrootsintegration.cpp
@@ -287,10 +287,12 @@ QPlatformFontDatabase *QWlrootsIntegration::fontDatabase() const
 
 QPlatformWindow *QWlrootsIntegration::createPlatformWindow(QWindow *window) const
 {
-    if (window->objectName() == QStringLiteral(QT_STRINGIFY(WAYLIB_SERVER_NAMESPACE))) {
+    if (QW::Window::check(window)) {
         Q_ASSERT(window->screen() && (window->screen()->handle() == m_placeholderScreen.get()
                                       || dynamic_cast<QWlrootsScreen*>(window->screen()->handle())));
         return new QWlrootsOutputWindow(window);
+    } else if (QW::RenderWindow::check(window)) {
+        return new QWlrootsRenderWindow(window);
     }
 
     return CALL_PROXY2(createPlatformWindow, nullptr, window);
@@ -331,7 +333,7 @@ public:
         m_format.setStencilBufferSize(8);
         m_format.setRenderableType(QSurfaceFormat::OpenGLES);
 
-        if (auto c = dynamic_cast<QW::OpenGLContext*>(m_context)) {
+        if (auto c = qobject_cast<QW::OpenGLContext*>(m_context)) {
             auto eglConfig = q_configFromGLFormat(c->eglDisplay(), m_format, false, EGL_WINDOW_BIT);
             if (eglConfig)
                 m_format = q_glFormatFromConfig(c->eglDisplay(), eglConfig, m_format);
@@ -364,7 +366,7 @@ public:
             return true;
         }
 
-        if (auto c = dynamic_cast<QW::OpenGLContext*>(m_context)) {
+        if (auto c = qobject_cast<QW::OpenGLContext*>(m_context)) {
             return eglMakeCurrent(c->eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, c->eglContext());
         }
 
@@ -374,7 +376,7 @@ public:
         if (m_currentSurface) {
             m_currentSurface->detachRenderer();
             m_currentSurface = nullptr;
-        } else if (auto c = dynamic_cast<QW::OpenGLContext*>(m_context)) {
+        } else if (auto c = qobject_cast<QW::OpenGLContext*>(m_context)) {
             eglMakeCurrent(c->eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
         }
     }
@@ -391,7 +393,7 @@ private:
 
 QPlatformOpenGLContext *QWlrootsIntegration::createPlatformOpenGLContext(QOpenGLContext *context) const
 {
-    if (context->objectName() == QStringLiteral(QT_STRINGIFY(WAYLIB_SERVER_NAMESPACE)))
+    if (QW::OpenGLContext::check(context))
         return new OpenGLContext(context);
 
     return CALL_PROXY(createPlatformOpenGLContext, context);
@@ -499,7 +501,7 @@ QPlatformTheme *QWlrootsIntegration::createPlatformTheme(const QString &name) co
 
 QPlatformOffscreenSurface *QWlrootsIntegration::createPlatformOffscreenSurface(QOffscreenSurface *surface) const
 {
-    if (surface->objectName() == QStringLiteral(QT_STRINGIFY(WAYLIB_SERVER_NAMESPACE)))
+    if (QW::OffscreenSurface::check(surface))
         return new OffscreenSurface(surface);
 
     return CALL_PROXY(createPlatformOffscreenSurface, surface);

--- a/src/server/platformplugin/qwlrootswindow.cpp
+++ b/src/server/platformplugin/qwlrootswindow.cpp
@@ -135,4 +135,40 @@ void QWlrootsOutputWindow::detachRenderer()
     bufferAttached = false;
 }
 
+QWlrootsRenderWindow::QWlrootsRenderWindow(QWindow *window)
+    : QPlatformWindow(window)
+{
+
+}
+
+void QWlrootsRenderWindow::initialize()
+{
+
+}
+
+WId QWlrootsRenderWindow::winId() const
+{
+    return reinterpret_cast<WId>(const_cast<QWlrootsRenderWindow*>(this));
+}
+
+qreal QWlrootsRenderWindow::devicePixelRatio() const
+{
+    return dpr;
+}
+
+void QWlrootsRenderWindow::setDevicePixelRatio(qreal dpr)
+{
+    if (qFuzzyCompare(this->dpr, dpr))
+        return;
+
+    this->dpr = dpr;
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
+    QEvent event(QEvent::ScreenChangeInternal);
+    QCoreApplication::sendEvent(window(), &event);
+#else
+    QWindowSystemInterface::handleWindowDevicePixelRatioChanged<QWindowSystemInterface::SynchronousDelivery>(window());
+#endif
+}
+
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/platformplugin/qwlrootswindow.h
+++ b/src/server/platformplugin/qwlrootswindow.h
@@ -44,4 +44,19 @@ private:
     QMetaObject::Connection onScreenGeometryConnection;
 };
 
+class Q_DECL_HIDDEN QWlrootsRenderWindow : public QPlatformWindow
+{
+public:
+    QWlrootsRenderWindow(QWindow *window);
+
+    void initialize() override;
+
+    WId winId() const override;
+    qreal devicePixelRatio() const override;
+    void setDevicePixelRatio(qreal dpr);
+
+private:
+    qreal dpr = 1.0;
+};
+
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/platformplugin/types.h
+++ b/src/server/platformplugin/types.h
@@ -14,36 +14,79 @@
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 namespace QW {
-class WAYLIB_SERVER_EXPORT Window : public QWindow
+class Window : public QWindow
 {
 public:
+    static constexpr QAnyStringView id() {
+        return "QWOutputWindow";
+    }
+
+    static bool check(QObject *obj) {
+        return obj->objectName() == id();
+    }
+
     explicit Window(QWindow *parent = nullptr)
         : QWindow(parent)
     {
-        setObjectName(QT_STRINGIFY(WAYLIB_SERVER_NAMESPACE));
+        setObjectName(id());
     }
 };
 
-class WAYLIB_SERVER_EXPORT OffscreenSurface : public QOffscreenSurface
+class RenderWindow : public QWindow
 {
 public:
+    static constexpr QAnyStringView id() {
+        return "QWRenderWindow";
+    }
+
+    static bool check(QObject *obj) {
+        return obj->objectName() == id();
+    }
+
+    explicit RenderWindow(QWindow *parent = nullptr)
+        : QWindow(parent)
+    {
+        setObjectName(id());
+    }
+};
+
+class OffscreenSurface : public QOffscreenSurface
+{
+public:
+    static constexpr QAnyStringView id() {
+        return "QWOffscreenSurface";
+    }
+
+    static bool check(QObject *obj) {
+        return obj->objectName() == id();
+    }
+
     explicit OffscreenSurface(QScreen *screen = nullptr, QObject *parent = nullptr)
         : QOffscreenSurface(screen, parent)
     {
-        setObjectName(QT_STRINGIFY(WAYLIB_SERVER_NAMESPACE));
+        setObjectName(id());
     }
 };
 
 #ifndef QT_NO_OPENGL
-class WAYLIB_SERVER_EXPORT OpenGLContext : public QOpenGLContext
+class OpenGLContext : public QOpenGLContext
 {
+    Q_OBJECT
 public:
+    static constexpr QAnyStringView id() {
+        return "QWOpenGLContext";
+    }
+
+    static bool check(QObject *obj) {
+        return obj->objectName() == id();
+    }
+
     explicit OpenGLContext(EGLDisplay egl, EGLContext context, QObject *parent = nullptr)
         : QOpenGLContext(parent)
         , m_eglDisplay(egl)
         , m_eglContext(context)
     {
-        setObjectName(QT_STRINGIFY(WAYLIB_SERVER_NAMESPACE));
+        setObjectName(id());
     }
 
     inline EGLDisplay eglDisplay() const {

--- a/src/server/qtquick/woutputhelper.cpp
+++ b/src/server/qtquick/woutputhelper.cpp
@@ -161,7 +161,7 @@ public:
 #ifndef WAYLIB_DISABLE_OUTPUT_DAMAGE
         damage->addWhole();
 #else
-        contentIsDirty = true;
+        setContentIsDirty(true);
 #endif
     }
 
@@ -215,7 +215,7 @@ void WOutputHelperPrivate::on_frame()
 void WOutputHelperPrivate::on_damage()
 {
     setContentIsDirty(true);
-    Q_EMIT q_func()->requestRender();
+    Q_EMIT q_func()->damaged();
 }
 #endif
 
@@ -430,8 +430,8 @@ void WOutputHelper::doneCurrent(QOpenGLContext *context)
 void WOutputHelper::resetState()
 {
     W_D(WOutputHelper);
-    d->contentIsDirty = false;
-    d->renderable = false;
+    d->setContentIsDirty(false);
+    d->setRenderable(false);
 }
 
 void WOutputHelper::update()

--- a/src/server/qtquick/woutputhelper.h
+++ b/src/server/qtquick/woutputhelper.h
@@ -50,6 +50,7 @@ public:
 
 Q_SIGNALS:
     void requestRender();
+    void damaged();
     void renderableChanged();
     void contentIsDirtyChanged();
 };

--- a/src/server/qtquick/woutputrenderwindow.h
+++ b/src/server/qtquick/woutputrenderwindow.h
@@ -53,6 +53,8 @@ public:
 
 public Q_SLOTS:
     void render();
+    void scheduleRender();
+    void update();
 
 Q_SIGNALS:
     void outputLayoutChanged();
@@ -60,6 +62,8 @@ Q_SIGNALS:
 private:
     void classBegin() override;
     void componentComplete() override;
+
+    bool event(QEvent *event) override;
 };
 
 WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
If different output have different scale value, and we change the render window when render a part of QtQuick scene graphs at WOutputRenderWindowPrivate::doRender, will lead to QQuickWindow::effectiveDevicePixelRatio changed, so some QQuickItem will update the resources for new device pixel ratio, like as QQuickShaderEffectSource, it will re-create QRhi's texture, this is expensive.

So we keep render window's devicePixelRatio to the maximize scale of multi outputs, don't change it when redner to different viewport, and re-set some properties of QSGRenderer before do render next frame, in order that transform QtQuick scene graphs content to different viewport.