### PR TITLE
Allow anchor a item to a WOutput in any place

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -54,6 +54,7 @@ set(QTQUICK_SOURCES
     qtquick/private/wquickbackend.cpp
     qtquick/private/wquickseat.cpp
     qtquick/private/wwaylandcompositor.cpp
+    qtquick/private/wquickcoordmapper.cpp
 )
 
 set(UTILS_SOURCES
@@ -121,6 +122,8 @@ set(PRIVATE_HEADERS
     platformplugin/types.h
     kernel/private/wsurface_p.h
     qtquick/private/woutputviewport_p.h
+    qtquick/private/wquickcoordmapper_p.h
+    qtquick/private/woutputpositioner_p.h
 )
 
 add_library(${TARGET}

--- a/src/server/qtquick/private/woutputpositioner_p.h
+++ b/src/server/qtquick/private/woutputpositioner_p.h
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include "woutputpositioner.h"
+
+#include <QQmlEngine>
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WOutputPositionerAttached : public QObject
+{
+    friend class WOutputPositioner;
+    Q_OBJECT
+    Q_PROPERTY(WOutputPositioner* positioner READ positioner NOTIFY positionerChanged FINAL)
+    QML_ANONYMOUS
+
+public:
+    explicit WOutputPositionerAttached(QObject *parent = nullptr);
+
+    WOutputPositioner *positioner() const;
+
+Q_SIGNALS:
+    void positionerChanged();
+
+private:
+    void setPositioner(WOutputPositioner *positioner);
+
+private:
+    WOutputPositioner *m_positioner = nullptr;
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquickcoordmapper.cpp
+++ b/src/server/qtquick/private/wquickcoordmapper.cpp
@@ -1,0 +1,96 @@
+// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wquickcoordmapper_p.h"
+#include "wquickobserver.h"
+
+#include <private/qquickitem_p.h>
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+WQuickCoordMapperHelper::WQuickCoordMapperHelper(QQuickItem *target)
+    : QObject(target)
+    , m_target(target)
+{
+
+}
+
+WQuickCoordMapper *WQuickCoordMapperHelper::get(WQuickObserver *target)
+{
+    for (auto i : list) {
+        if (i->m_target == target)
+            return i;
+    }
+
+    auto mapper = new WQuickCoordMapper(target, m_target);
+    connect(mapper, &WQuickCoordMapper::destroyed, this, [this] {
+        list.removeOne(qobject_cast<WQuickCoordMapper*>(QObject::sender()));
+    });
+    list.append(mapper);
+
+    return mapper;
+}
+
+WQuickCoordMapperAttached::WQuickCoordMapperAttached(QQuickItem *target)
+    : QObject(target)
+    , m_target(target)
+{
+    connect(target, &QQuickItem::parentChanged, this, &WQuickCoordMapperAttached::helperChanged);
+}
+
+WQuickCoordMapperHelper *WQuickCoordMapperAttached::helper() const
+{
+    auto parent = m_target->parentItem();
+    if (!parent)
+        return nullptr;
+
+    auto helper = parent->findChild<WQuickCoordMapperHelper*>(QString(), Qt::FindDirectChildrenOnly);
+    if (!helper)
+        helper = new WQuickCoordMapperHelper(parent);
+
+    return helper;
+}
+
+class WQuickCoordMapperPrivate : public QQuickItemPrivate
+{
+public:
+    bool transformChanged(QQuickItem *transformedItem) override {
+        Q_Q(WQuickCoordMapper);
+        q->updatePosition();
+
+        return QQuickItemPrivate::transformChanged(transformedItem);
+    }
+
+    Q_DECLARE_PUBLIC(WQuickCoordMapper)
+};
+
+WQuickCoordMapper::WQuickCoordMapper(WQuickObserver *target, QQuickItem *parent)
+    : QQuickItem(*new WQuickCoordMapperPrivate(), parent)
+    , m_target(target)
+{
+    setFlag(QQuickItem::ItemObservesViewport);
+
+    connect(target, &WQuickObserver::maybeGlobalPositionChanged,
+            this, &WQuickCoordMapper::updatePosition);
+
+    bindableWidth().setBinding(target->bindableWidth().makeBinding());
+    bindableHeight().setBinding(target->bindableHeight().makeBinding());
+}
+
+void WQuickCoordMapper::updatePosition()
+{
+    auto parent = parentItem();
+    Q_ASSERT(parent);
+    const QPointF &pos = m_target->globalPosition();
+    setPosition(parent->mapFromGlobal(pos));
+}
+
+WQuickCoordMapperAttached *WQuickCoordMapper::qmlAttachedProperties(QObject *target)
+{
+    auto item = qobject_cast<QQuickItem*>(target);
+    if (!item)
+        return nullptr;
+    return new WQuickCoordMapperAttached(item);
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquickcoordmapper_p.h
+++ b/src/server/qtquick/private/wquickcoordmapper_p.h
@@ -1,0 +1,72 @@
+// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <wglobal.h>
+
+#include <QObject>
+#include <QQuickItem>
+
+Q_MOC_INCLUDE("wquickobserver.h")
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WQuickObserver;
+class WQuickCoordMapper;
+class WQuickCoordMapperHelper : public QObject
+{
+    Q_OBJECT
+    QML_ANONYMOUS
+
+public:
+    explicit WQuickCoordMapperHelper(QQuickItem *target);
+
+public Q_SLOTS:
+    WQuickCoordMapper *get(WQuickObserver *target);
+
+private:
+    QQuickItem *m_target;
+    QList<WQuickCoordMapper*> list;
+};
+
+class WQuickCoordMapperAttached : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(WAYLIB_SERVER_NAMESPACE::WQuickCoordMapperHelper* helper READ helper NOTIFY helperChanged FINAL)
+    QML_ANONYMOUS
+
+public:
+    explicit WQuickCoordMapperAttached(QQuickItem *target);
+
+    WQuickCoordMapperHelper *helper() const;
+
+Q_SIGNALS:
+    void helperChanged();
+
+private:
+    QQuickItem *m_target;
+};
+
+class WQuickCoordMapperPrivate;
+class WQuickCoordMapper : public QQuickItem
+{
+    friend class WQuickCoordMapperHelper;
+    Q_OBJECT
+    Q_DECLARE_PRIVATE(WQuickCoordMapper)
+    QML_ATTACHED(WQuickCoordMapperAttached)
+    QML_NAMED_ELEMENT(CoordMapper)
+    QML_UNCREATABLE("Only using for attached property")
+
+public:
+    explicit WQuickCoordMapper(WQuickObserver *target, QQuickItem *parent);
+
+    static WQuickCoordMapperAttached *qmlAttachedProperties(QObject *target);
+
+private:
+    void updatePosition();
+
+    WQuickObserver *m_target;
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/woutputpositioner.h
+++ b/src/server/qtquick/woutputpositioner.h
@@ -8,11 +8,13 @@
 #include <QQuickItem>
 
 Q_MOC_INCLUDE(<wquickoutputlayout.h>)
+Q_MOC_INCLUDE(<woutputpositioner_p.h>)
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WOutput;
 class WQuickOutputLayout;
+class WOutputPositionerAttached;
 class WOutputPositionerPrivate;
 class WAYLIB_SERVER_EXPORT WOutputPositioner : public WQuickObserver, public WObject
 {
@@ -22,10 +24,13 @@ class WAYLIB_SERVER_EXPORT WOutputPositioner : public WQuickObserver, public WOb
     Q_PROPERTY(WQuickOutputLayout* layout READ layout WRITE setLayout NOTIFY layoutChanged)
     Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio WRITE setDevicePixelRatio NOTIFY devicePixelRatioChanged)
     QML_NAMED_ELEMENT(OutputPositioner)
+    QML_ATTACHED(WOutputPositionerAttached)
 
 public:
     explicit WOutputPositioner(QQuickItem *parent = nullptr);
     ~WOutputPositioner();
+
+    static WOutputPositionerAttached *qmlAttachedProperties(QObject *target);
 
     WOutput *output() const;
     void setOutput(WOutput *newOutput);


### PR DESCRIPTION
Add attached properties:
1. WOutputPositionerAttached: Get WOutputPositioner object from WOutput.
2. WQuickCoordMapperAttached: Get WQuickCoordMapper object from WQuickObserver.