### PR TITLE
Fix crash at 'assert(renderer != NULL)' in wlroots

### DIFF
--- a/src/server/kernel/wcursor.cpp
+++ b/src/server/kernel/wcursor.cpp
@@ -136,7 +136,7 @@ static inline const char *qcursorToType(const QCursor &cursor) {
 
 void WCursorPrivate::updateCursorImage()
 {
-    if (!outputLayout || outputLayout->outputs().isEmpty())
+    if (!outputLayout)
         return;
 
     if (seat && seat->pointerFocusSurface())
@@ -485,7 +485,6 @@ void WCursor::setLayout(WOutputLayout *layout)
 
     connect(d->outputLayout, &WOutputLayout::outputAdded, this, [this, d] (WOutput *o) {
         o->addCursor(this);
-        d->updateCursorImage();
     });
 
     d->updateCursorImage();

--- a/src/server/qtquick/woutputrenderwindow.cpp
+++ b/src/server/qtquick/woutputrenderwindow.cpp
@@ -300,9 +300,6 @@ void WOutputRenderWindowPrivate::init()
 
 void WOutputRenderWindowPrivate::init(OutputHelper *helper)
 {
-    auto qwoutput = helper->qwoutput();
-    qwoutput->initRender(compositor->allocator(), compositor->renderer());
-
     W_Q(WOutputRenderWindow);
     QMetaObject::invokeMethod(q, &WOutputRenderWindow::scheduleRender, Qt::QueuedConnection);
     helper->init();
@@ -508,6 +505,10 @@ void WOutputRenderWindow::attach(WOutputViewport *output)
     Q_ASSERT(output->output());
 
     d->outputs << new OutputHelper(output, this);
+    if (d->compositor) {
+        auto qwoutput = d->outputs.last()->qwoutput();
+        qwoutput->initRender(d->compositor->allocator(), d->compositor->renderer());
+    }
 
     if (!d->isInitialized())
         return;
@@ -546,6 +547,11 @@ void WOutputRenderWindow::setCompositor(WWaylandCompositor *newCompositor)
     Q_D(WOutputRenderWindow);
     Q_ASSERT(!d->compositor);
     d->compositor = newCompositor;
+
+    for (auto output : d->outputs) {
+        auto qwoutput = output->qwoutput();
+        qwoutput->initRender(d->compositor->allocator(), d->compositor->renderer());
+    }
 
     if (d->componentCompleted && d->compositor->isPolished()) {
         d->init();


### PR DESCRIPTION
After https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4295 Must ensure the renderer of wlr_output is initialized before add it to wlr_output_layout and set cursor buffer or xcursor to wlr_cursor.