### PR TITLE
Fix crashes caused by mouse events before destructuring

### DIFF
--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -114,7 +114,7 @@ public:
     }
 
     bool contains(const QPointF &point) const override {
-        if (Q_UNLIKELY(!d() || !d()->surface))
+        if (Q_UNLIKELY(!d() || !d()->surface || !d()->surface->handle()))
             return false;
 
         return d()->surface->inputRegionContains(point);


### PR DESCRIPTION
wxdgsurface executes deletelater, wlr_surface has been released, but wxdgsurface has not been deleted, if the event loop handles the extrusion event at this time, it will result in a null pointer.