### PR TITLE
Fix crashes when destory a maximized surface

### DIFF
--- a/examples/tinywl/XdgStackWorkspace.qml
+++ b/examples/tinywl/XdgStackWorkspace.qml
@@ -54,7 +54,7 @@ Item {
             states: [
                 State {
                     name: "maximize"
-                    when: waylandSurface && waylandSurface.isMaximized && outputCoordMapper
+                    when: waylandSurface.isMaximized && outputCoordMapper
                     PropertyChanges {
                         restoreEntryValues: true
                         surface {


### PR DESCRIPTION
When a waylandSurface was destoryed, State will become false, if State was true before, this triggers a resize event for the destoryed surface, causing a crash