### PR TITLE
Refactor WSeat's policy of event filter

### DIFF
--- a/examples/tinywl/Main.qml
+++ b/examples/tinywl/Main.qml
@@ -87,6 +87,12 @@ Item {
         width: outputRowLayout.implicitWidth + outputRowLayout.x
         height: outputRowLayout.implicitHeight + outputRowLayout.y
 
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.ArrowCursor
+            onPressed: Helper.clearFocus(renderWindow)
+        }
+
         Row {
             id: outputRowLayout
 

--- a/examples/tinywl/helper.h
+++ b/examples/tinywl/helper.h
@@ -9,6 +9,8 @@
 #include <WSurfaceItem>
 #include <WOutput>
 
+Q_DECLARE_OPAQUE_POINTER(QWindow*)
+
 struct wlr_output_event_request_state;
 QW_USE_NAMESPACE
 WAYLIB_SERVER_USE_NAMESPACE
@@ -32,6 +34,7 @@ public Q_SLOTS:
     WSurface *getFocusSurfaceFrom(QObject *object);
 
     void allowNonDrmOutputAutoChangeMode(WOutput *output);
+    void clearFocus(QWindow *window);
 
 signals:
     void activatedSurfaceChanged();
@@ -39,7 +42,6 @@ signals:
 private:
     bool eventFilter(WSeat *seat, QWindow *watched, QInputEvent *event) override;
     bool eventFilter(WSeat *seat, WSurface *watched, QObject *surfaceItem, QInputEvent *event) override;
-    bool ignoredEventFilter(WSeat *seat, QWindow *watched, QInputEvent *event) override;
 
     void setActivateSurface(WXdgSurface *newActivate);
     void onOutputRequeseState(wlr_output_event_request_state *newState);

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -105,6 +105,13 @@ void Helper::allowNonDrmOutputAutoChangeMode(WOutput *output)
     connect(output->handle(), &QWOutput::requestState, this, &Helper::onOutputRequeseState);
 }
 
+void Helper::clearFocus(QWindow *window)
+{
+    if (auto item = qobject_cast<QQuickItem*>(window->focusObject()))
+        item->setFocus(false);
+    setActivateSurface(nullptr);
+}
+
 bool Helper::eventFilter(WSeat *seat, QWindow *watched, QInputEvent *event)
 {
     if (watched) {
@@ -176,20 +183,6 @@ bool Helper::eventFilter(WSeat *seat, WSurface *watched, QObject *surfaceItem, Q
         Q_ASSERT(xdgSurface->surface() == watched);
         if (!xdgSurface->doesNotAcceptFocus())
             setActivateSurface(xdgSurface);
-    }
-
-    return false;
-}
-
-bool Helper::ignoredEventFilter(WSeat *seat, QWindow *watched, QInputEvent *event)
-{
-    Q_UNUSED(seat);
-
-    if (watched && event->type() == QEvent::MouseButtonPress) {
-        // clear focus
-        if (auto item = qobject_cast<QQuickItem*>(watched->focusObject()))
-            item->setFocus(false);
-        setActivateSurface(nullptr);
     }
 
     return false;

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -149,9 +149,6 @@ bool Helper::eventFilter(WSeat *seat, QWindow *watched, QInputEvent *event)
             return true;
         } else if (event->type() == QEvent::MouseButtonRelease) {
             stop();
-            // Don't continue delivery this mouse event, bacuse this event
-            // is working for move-resize job.
-            return true;
         }
     }
 

--- a/src/server/kernel/private/wcursor_p.h
+++ b/src/server/kernel/private/wcursor_p.h
@@ -50,7 +50,7 @@ public:
     QCursor cursor;
 
     WSeat *seat = nullptr;
-    QPointer<QQuickWindow> eventWindow;
+    QPointer<QWindow> eventWindow;
     WOutputLayout *outputLayout = nullptr;
     QList<WInputDevice*> deviceList;
 

--- a/src/server/kernel/wcursor.cpp
+++ b/src/server/kernel/wcursor.cpp
@@ -368,7 +368,7 @@ WSeat *WCursor::seat() const
     return d->seat;
 }
 
-QQuickWindow *WCursor::eventWindow() const
+QWindow *WCursor::eventWindow() const
 {
     W_DC(WCursor);
     return d->eventWindow.get();
@@ -384,7 +384,7 @@ const QPointingDevice *getDevice(const QString &seatName) {
     return nullptr;
 }
 
-void WCursor::setEventWindow(QQuickWindow *window)
+void WCursor::setEventWindow(QWindow *window)
 {
     W_D(WCursor);
     if (d->eventWindow == window)

--- a/src/server/kernel/wcursor.h
+++ b/src/server/kernel/wcursor.h
@@ -11,7 +11,7 @@
 
 QT_BEGIN_NAMESPACE
 class QCursor;
-class QQuickWindow;
+class QWindow;
 QT_END_NAMESPACE
 
 QW_BEGIN_NAMESPACE
@@ -47,8 +47,8 @@ public:
     Qt::MouseButton button() const;
 
     WSeat *seat() const;
-    QQuickWindow *eventWindow() const;
-    void setEventWindow(QQuickWindow *window);
+    QWindow *eventWindow() const;
+    void setEventWindow(QWindow *window);
 
     static Qt::CursorShape defaultCursor();
 

--- a/src/server/kernel/wseat.cpp
+++ b/src/server/kernel/wseat.cpp
@@ -62,12 +62,8 @@ public:
     }
 
     inline bool doNotifyMotion(WSurface *target, QPointF localPos, uint32_t timestamp) {
-        if (!pointerFocusSurface()) {
-            doEnter(target, localPos);
-        } else {
-            Q_ASSERT(pointerFocusSurface() == target->handle()->handle());
-            handle()->pointerNotifyMotion(timestamp, localPos.x(), localPos.y());
-        }
+        Q_ASSERT(pointerFocusSurface() == target->handle()->handle());
+        handle()->pointerNotifyMotion(timestamp, localPos.x(), localPos.y());
         return true;
     }
     inline bool doNotifyButton(uint32_t button, wlr_button_state state, uint32_t timestamp) {
@@ -524,8 +520,9 @@ void WSeat::notifyMotion(WCursor *cursor, WInputDevice *device, uint32_t timesta
     const QPointF &global = cursor->position();
     const QPointF local = w ? global - QPointF(w->position()) : QPointF();
 
-    QMouseEvent e(QEvent::MouseMove, local, global, cursor->button(),
+    QMouseEvent e(QEvent::MouseMove, local, global, Qt::NoButton,
                   cursor->state(), d->keyModifiers, qwDevice);
+    Q_ASSERT(e.isUpdateEvent());
     e.setTimestamp(timestamp);
 
     if (Q_UNLIKELY(d->eventFilter)) {
@@ -564,6 +561,10 @@ void WSeat::notifyButton(WCursor *cursor, WInputDevice *device, Qt::MouseButton 
 
     QMouseEvent e(et, local, global, button,
                   cursor->state(), d->keyModifiers, qwDevice);
+    if (et == QEvent::MouseButtonPress)
+        Q_ASSERT(e.isBeginEvent());
+    else
+        Q_ASSERT(e.isEndEvent());
     e.setTimestamp(timestamp);
 
     if (Q_UNLIKELY(d->eventFilter)) {

--- a/src/server/kernel/wseat.h
+++ b/src/server/kernel/wseat.h
@@ -37,7 +37,6 @@ public:
 protected:
     virtual bool eventFilter(WSeat *seat, WSurface *watched, QObject *shellObject, QInputEvent *event);
     virtual bool eventFilter(WSeat *seat, QWindow *watched, QInputEvent *event);
-    virtual bool ignoredEventFilter(WSeat *seat, QWindow *watched, QInputEvent *event);
 };
 
 class WCursor;
@@ -81,9 +80,13 @@ protected:
     friend class WOutputPrivate;
     friend class WCursor;
     friend class WCursorPrivate;
+    friend class QWlrootsRenderWindow;
 
     void create(WServer *server) override;
     void destroy(WServer *server) override;
+
+    // for event filter
+    bool filterInputEvent(QWindow *targetWindow, QInputEvent *event);
 
     // pointer
     void notifyMotion(WCursor *cursor, WInputDevice *device, uint32_t timestamp);

--- a/src/server/platformplugin/qwlrootswindow.cpp
+++ b/src/server/platformplugin/qwlrootswindow.cpp
@@ -188,6 +188,7 @@ bool QWlrootsRenderWindow::windowEvent(QEvent *event)
         auto device = WInputDevice::from(ie->device());
         Q_ASSERT(device);
         lastActiveCursor = device->seat()->cursor();
+        return device->seat()->filterInputEvent(window(), ie);
     }
 
     return false;


### PR DESCRIPTION
The new dispatch order of event:

1. WInputDevice
2. WSeat::notify* functions
3. QGuiApplication::sendEvent
4. QWlrootsRenderWindow::windowEvent
5. WSeat::filterInputEvent
6. WOutputRenderWindow::event
7. WSurfaceItem::eventItem
8. WSeat::sendEvent
9. wayland clients