### PR TITLE
Allow to delay destroy WSurfaceItem

### DIFF
--- a/src/server/kernel/private/wsurface_p.h
+++ b/src/server/kernel/private/wsurface_p.h
@@ -51,7 +51,6 @@ public:
     bool hasSubsurface = false;
 
     QW_NAMESPACE::QWBuffer *buffer = nullptr;
-    mutable QW_NAMESPACE::QWTexture *texture = nullptr;
     QVector<WOutput*> outputs;
     WOutput *primaryOutput = nullptr;
     QMetaObject::Connection frameDoneConnection;

--- a/src/server/kernel/wsurface.cpp
+++ b/src/server/kernel/wsurface.cpp
@@ -38,9 +38,6 @@ WSurfacePrivate::~WSurfacePrivate()
     if (handle)
         handle->setData(this, nullptr);
 
-    if (texture)
-        delete texture;
-
     if (buffer)
         buffer->unlock();
 }
@@ -130,9 +127,6 @@ void WSurfacePrivate::setPrimaryOutput(WOutput *output)
 
 void WSurfacePrivate::setBuffer(QWBuffer *newBuffer)
 {
-    if (texture)
-        delete texture;
-
     if (buffer) {
         if (auto clientBuffer = QWClientBuffer::get(buffer)) {
             Q_ASSERT(clientBuffer->handle()->n_ignore_locks > 0);
@@ -152,7 +146,7 @@ void WSurfacePrivate::setBuffer(QWBuffer *newBuffer)
         buffer = nullptr;
     }
 
-    Q_EMIT q_func()->textureChanged();
+    Q_EMIT q_func()->bufferChanged();
 }
 
 void WSurfacePrivate::updateBuffer()
@@ -270,40 +264,16 @@ int WSurface::bufferScale() const
     return d->nativeHandle()->current.scale;
 }
 
-QWTexture *WSurface::texture() const
+QPoint WSurface::bufferOffset() const
 {
     W_DC(WSurface);
-    auto textureHandle = d->handle->getTexture();
-    if (textureHandle)
-        return textureHandle;
-
-    if (d->texture)
-        return d->texture;
-
-    if (!d->primaryOutput)
-        return nullptr;
-
-    auto renderer = d->primaryOutput->renderer();
-    if (!renderer)
-        return nullptr;
-
-    if (!d->buffer)
-        return nullptr;
-
-    d->texture = QWTexture::fromBuffer(renderer, d->buffer);
-    return d->texture;
+    return QPoint(d->nativeHandle()->current.dx, d->nativeHandle()->current.dy);
 }
 
 QWBuffer *WSurface::buffer() const
 {
     W_DC(WSurface);
     return d->buffer;
-}
-
-QPoint WSurface::textureOffset() const
-{
-    W_DC(WSurface);
-    return QPoint(0, 0);
 }
 
 void WSurface::notifyFrameDone()

--- a/src/server/kernel/wsurface.h
+++ b/src/server/kernel/wsurface.h
@@ -51,10 +51,8 @@ public:
     QSize bufferSize() const;
     WLR::Transform orientation() const;
     int bufferScale() const;
-
-    QW_NAMESPACE::QWTexture *texture() const;
+    QPoint bufferOffset() const;
     QW_NAMESPACE::QWBuffer *buffer() const;
-    QPoint textureOffset() const;
 
     void notifyFrameDone();
     WOutput *primaryOutput() const;
@@ -75,7 +73,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void primaryOutputChanged();
     void mappedChanged();
-    void textureChanged();
+    void bufferChanged();
     void isSubsurfaceChanged();
     void hasSubsurfaceChanged();
     void newSubsurface(WSurface *subsurface);

--- a/src/server/qtquick/private/wqmldynamiccreator.cpp
+++ b/src/server/qtquick/private/wqmldynamiccreator.cpp
@@ -152,7 +152,8 @@ void WQmlCreatorComponent::destroy(QSharedPointer<WQmlCreatorDelegateData> data)
         Q_EMIT objectRemoved(obj, p);
         notifyCreatorObjectRemoved(m_creator, obj, p);
 
-        obj->deleteLater();
+        if (m_autoDestroy)
+            obj->deleteLater();
     }
 }
 
@@ -268,6 +269,12 @@ QList<QSharedPointer<WQmlCreatorDelegateData> > WQmlCreatorComponent::datas() co
     return m_datas;
 }
 
+// If autoDestroy is disabled, can using this interface to manual manager the object's life.
+void WQmlCreatorComponent::destroyObject(QObject *object)
+{
+    object->deleteLater();
+}
+
 QString WQmlCreatorComponent::chooserRole() const
 {
     return m_chooserRole;
@@ -296,6 +303,19 @@ void WQmlCreatorComponent::setChooserRoleValue(const QVariant &newChooserRoleVal
     reset();
 
     Q_EMIT chooserRoleValueChanged();
+}
+
+bool WQmlCreatorComponent::autoDestroy() const
+{
+    return m_autoDestroy;
+}
+
+void WQmlCreatorComponent::setAutoDestroy(bool newAutoDestroy)
+{
+    if (m_autoDestroy == newAutoDestroy)
+        return;
+    m_autoDestroy = newAutoDestroy;
+    Q_EMIT autoDestroyChanged();
 }
 
 WQmlCreator::WQmlCreator(QObject *parent)

--- a/src/server/qtquick/private/wqmldynamiccreator_p.h
+++ b/src/server/qtquick/private/wqmldynamiccreator_p.h
@@ -74,6 +74,7 @@ class WAYLIB_SERVER_EXPORT WQmlCreatorComponent : public WAbstractCreatorCompone
     Q_PROPERTY(QObject* parent READ parent WRITE setParent NOTIFY parentChanged FINAL)
     Q_PROPERTY(QString chooserRole READ chooserRole WRITE setChooserRole NOTIFY chooserRoleChanged FINAL)
     Q_PROPERTY(QVariant chooserRoleValue READ chooserRoleValue WRITE setChooserRoleValue NOTIFY chooserRoleValueChanged FINAL)
+    Q_PROPERTY(bool autoDestroy READ autoDestroy WRITE setAutoDestroy NOTIFY autoDestroyChanged FINAL)
     QML_NAMED_ELEMENT(DynamicCreatorComponent)
     Q_CLASSINFO("DefaultProperty", "delegate")
 
@@ -92,15 +93,21 @@ public:
     QVariant chooserRoleValue() const;
     void setChooserRoleValue(const QVariant &newChooserRoleValue);
 
+    bool autoDestroy() const;
+    void setAutoDestroy(bool newAutoDestroy);
+
     QObject *parent() const;
     void setParent(QObject *newParent);
 
     QList<QSharedPointer<WQmlCreatorDelegateData>> datas() const override;
 
+    Q_INVOKABLE void destroyObject(QObject *object);
+
 Q_SIGNALS:
     void parentChanged();
     void chooserRoleChanged();
     void chooserRoleValueChanged();
+    void autoDestroyChanged();
 
     void objectAdded(QObject *object, const QJSValue &initialProperties);
     void objectRemoved(QObject *object, const QJSValue &initialProperties);
@@ -121,6 +128,7 @@ private:
     QObject *m_parent = nullptr;
     QString m_chooserRole;
     QVariant m_chooserRoleValue;
+    bool m_autoDestroy = true;
 
     QList<QSharedPointer<WQmlCreatorDelegateData>> m_datas;
 };

--- a/src/server/qtquick/private/wquickxdgshell.cpp
+++ b/src/server/qtquick/private/wquickxdgshell.cpp
@@ -98,7 +98,7 @@ void WXdgSurfaceItem::setSurface(WXdgSurface *surface)
         return;
 
     m_surface = surface;
-    WSurfaceItem::setSurface(surface->surface());
+    WSurfaceItem::setSurface(surface ? surface->surface() : nullptr);
 
     Q_EMIT surfaceChanged();
 }

--- a/src/server/qtquick/wsurfaceitem.h
+++ b/src/server/qtquick/wsurfaceitem.h
@@ -26,6 +26,7 @@ class WAYLIB_SERVER_EXPORT WSurfaceItem : public QQuickItem
     Q_PROPERTY(QQuickItem* contentItem READ contentItem CONSTANT)
     Q_PROPERTY(QQuickItem* eventItem READ eventItem CONSTANT)
     Q_PROPERTY(ResizeMode resizeMode READ resizeMode WRITE setResizeMode NOTIFY resizeModeChanged FINAL)
+    Q_PROPERTY(bool cacheLastBuffer READ cacheLastBuffer WRITE setCacheLastBuffer NOTIFY cacheLastBufferChanged FINAL)
     QML_NAMED_ELEMENT(SurfaceItem)
 
 public:
@@ -52,17 +53,22 @@ public:
     ResizeMode resizeMode() const;
     void setResizeMode(ResizeMode newResizeMode);
 
+    bool cacheLastBuffer() const;
+    void setCacheLastBuffer(bool newCacheLastBuffer);
+
 Q_SIGNALS:
     void surfaceChanged();
     void subsurfaceAdded(WSurfaceItem *item);
     void subsurfaceRemoved(WSurfaceItem *item);
     void resizeModeChanged();
+    void cacheLastBufferChanged();
 
 protected:
     void componentComplete() override;
     void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
     void itemChange(ItemChange change, const ItemChangeData &data) override;
     void focusInEvent(QFocusEvent *event) override;
+    void releaseResources() override;
 
     Q_SLOT virtual void onSurfaceCommit();
     virtual void initSurface();


### PR DESCRIPTION
Support add animation when surface removed or close, the WSurfaceItem can lock the last frame buffer of wl_surface, you can using the WSurfaceItem after WSurface destroyed.