### PR TITLE
Only set StretchFactor when it's not undefined

### DIFF
--- a/examples/tinywl/TiledWorkspace.qml
+++ b/examples/tinywl/TiledWorkspace.qml
@@ -63,8 +63,15 @@ Item {
                 Layout.minimumHeight: Math.max(surface.minimumSize.height, 50)
                 Layout.maximumWidth: surface.maximumSize.width
                 Layout.maximumHeight: surface.maximumSize.height
-                Layout.horizontalStretchFactor: 1
-                Layout.verticalStretchFactor: 1
+                Component.onCompleted: {
+                    if (Layout.horizontalStretchFactor !== undefined) {
+                        // introduced in Qt 6.5
+                        Layout.horizontalStretchFactor = 1
+                    }
+                    if (Layout.verticalStretchFactor !== undefined) {
+                        Layout.verticalStretchFactor = 1
+                    }
+                }
 
                 TiledToplevelHelper {
                     id: helper
@@ -138,8 +145,15 @@ Item {
                 Layout.minimumHeight: Math.max(surface.minimumSize.height, 50)
                 Layout.maximumWidth: surface.maximumSize.width
                 Layout.maximumHeight: surface.maximumSize.height
-                Layout.horizontalStretchFactor: 1
-                Layout.verticalStretchFactor: 1
+                Component.onCompleted: {
+                    if (Layout.horizontalStretchFactor !== undefined) {
+                        // introduced in Qt 6.5
+                        Layout.horizontalStretchFactor = 1
+                    }
+                    if (Layout.verticalStretchFactor !== undefined) {
+                        Layout.verticalStretchFactor = 1
+                    }
+                }
 
                 TiledToplevelHelper {
                     id: helper

--- a/tests/manual/pinchhandler/Main.qml
+++ b/tests/manual/pinchhandler/Main.qml
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
-// Fix error in Qt 6.4 module "QtQuick.Window" is not installed
-// don't need annotations in Qt >= 6.5
-//import QtQuick.Window
+import QtQuick.Window
 import QtQuick.Controls
 
 Window {

--- a/tests/manual/subsurface/Main.qml
+++ b/tests/manual/subsurface/Main.qml
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
-// Fix error in Qt 6.4 module "QtQuick.Window" is not installed
-// don't need annotations in Qt >= 6.5
-//import QtQuick.Window
+import QtQuick.Window
 import QtQuick.Controls
 import subsurface
 


### PR DESCRIPTION
1. Layout.horizontalStretchFactor was introduced in qt 6.5, we can't use in qt 6.4

2. we can use QtQuick.Window in qt 6.4, need apt install qml6-module-qtquick-window in deepin