### PR TITLE
Allow specified a owns WSocket to WServerInterface

### DIFF
--- a/src/server/kernel/wbackend.cpp
+++ b/src/server/kernel/wbackend.cpp
@@ -196,4 +196,9 @@ void WBackend::destroy(WServer *server)
     m_handle = nullptr;
 }
 
+wl_global *WBackend::global() const
+{
+    return nullptr;
+}
+
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/kernel/wbackend.h
+++ b/src/server/kernel/wbackend.h
@@ -30,6 +30,7 @@ protected:
 
     void create(WServer *server) override;
     void destroy(WServer *server) override;
+    wl_global *global() const override;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/kernel/wseat.cpp
+++ b/src/server/kernel/wseat.cpp
@@ -964,6 +964,12 @@ void WSeat::destroy(WServer *)
     }
 }
 
+wl_global *WSeat::global() const
+{
+    W_D(const WSeat);
+    return d->nativeHandle()->global;
+}
+
 bool WSeat::filterEventBeforeDisposeStage(QWindow *targetWindow, QInputEvent *event)
 {
     W_D(WSeat);

--- a/src/server/kernel/wseat.h
+++ b/src/server/kernel/wseat.h
@@ -90,6 +90,7 @@ protected:
 
     void create(WServer *server) override;
     void destroy(WServer *server) override;
+    wl_global *global() const override;
 
     // for event filter
     bool filterEventBeforeDisposeStage(QWindow *targetWindow, QInputEvent *event);

--- a/src/server/kernel/wserver.h
+++ b/src/server/kernel/wserver.h
@@ -27,6 +27,7 @@ typedef bool (*GlobalFilterFunc)(const wl_client *client,
                                  void *data);
 
 class WServer;
+class WSocket;
 class WServerInterface
 {
 public:
@@ -47,12 +48,22 @@ public:
         return m_server;
     }
 
+    inline void setOwnsSocket(const WSocket *socket) {
+        m_ownsSocket = socket;
+    }
+    inline const WSocket *ownsSocket() const {
+        return m_ownsSocket;
+    }
+
 protected:
     void *m_handle = nullptr;
     WServer *m_server = nullptr;
+    const WSocket *m_ownsSocket = nullptr;
 
     virtual void create(WServer *server) = 0;
     virtual void destroy(WServer *server) = 0;
+    virtual wl_global *global() const = 0;
+
     friend class WServer;
     friend class WServerPrivate;
 };
@@ -92,6 +103,7 @@ public:
     QVector<WServerInterface*> interfaceList() const;
     QVector<WServerInterface*> findInterfaces(void *handle) const;
     WServerInterface *findInterface(void *handle) const;
+    WServerInterface *findInterface(const wl_global *global) const;
     template<typename Interface>
     QVector<Interface*> findInterfaces() const {
         QVector<Interface*> list;

--- a/src/server/kernel/wsocket.cpp
+++ b/src/server/kernel/wsocket.cpp
@@ -155,7 +155,7 @@ struct WlClientDestroyListener {
 
     ~WlClientDestroyListener();
 
-    static WlClientDestroyListener *get(wl_client *client);
+    static WlClientDestroyListener *get(const wl_client *client);
     static void handle_destroy(struct wl_listener *listener, void *);
 
     wl_listener destroy;
@@ -167,9 +167,10 @@ WlClientDestroyListener::~WlClientDestroyListener()
     wl_list_remove(&destroy.link);
 }
 
-WlClientDestroyListener *WlClientDestroyListener::get(wl_client *client)
+WlClientDestroyListener *WlClientDestroyListener::get(const wl_client *client)
 {
-    wl_listener *listener = wl_client_get_destroy_listener(client, WlClientDestroyListener::handle_destroy);
+    wl_listener *listener = wl_client_get_destroy_listener(const_cast<wl_client*>(client),
+                                                           WlClientDestroyListener::handle_destroy);
     if (!listener) {
         return nullptr;
     }
@@ -264,7 +265,7 @@ WSocket::WSocket(bool freezeClientWhenDisable, WSocket *parentSocket, QObject *p
 
 }
 
-WSocket *WSocket::get(wl_client *client)
+WSocket *WSocket::get(const wl_client *client)
 {
     if (auto tmp = WlClientDestroyListener::get(client))
         return tmp->socket;

--- a/src/server/kernel/wsocket.h
+++ b/src/server/kernel/wsocket.h
@@ -27,7 +27,7 @@ class WAYLIB_SERVER_EXPORT WSocket : public QObject, public WObject
 public:
     explicit WSocket(bool freezeClientWhenDisable, WSocket *parentSocket = nullptr, QObject *parent = nullptr);
 
-    static WSocket *get(wl_client *client);
+    static WSocket *get(const wl_client *client);
 
     WSocket *parentSocket() const;
     WSocket *rootSocket() const;

--- a/src/server/kernel/wxdgshell.cpp
+++ b/src/server/kernel/wxdgshell.cpp
@@ -96,6 +96,7 @@ void WXdgShell::create(WServer *server)
     QObject::connect(xdg_shell, &QWXdgShell::newSurface, server->slotOwner(), [this] (wlr_xdg_surface *surface) {
         d_func()->on_new_xdg_surface(surface);
     });
+    m_handle = xdg_shell;
 }
 
 void WXdgShell::destroy(WServer *server)
@@ -110,6 +111,12 @@ void WXdgShell::destroy(WServer *server)
         surfaceRemoved(surface);
         surface->deleteLater();
     }
+}
+
+wl_global *WXdgShell::global() const
+{
+    auto handle = nativeInterface<QWXdgShell>();
+    return handle->handle()->global;
 }
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/kernel/wxdgshell.h
+++ b/src/server/kernel/wxdgshell.h
@@ -23,6 +23,7 @@ protected:
 
     void create(WServer *server) override;
     void destroy(WServer *server) override;
+    wl_global *global() const override;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/kernel/wxwayland.cpp
+++ b/src/server/kernel/wxwayland.cpp
@@ -13,6 +13,7 @@
 extern "C" {
 #define class className
 #include <wlr/xwayland.h>
+#include <wlr/xwayland/shell.h>
 #undef class
 }
 
@@ -227,6 +228,11 @@ void WXWayland::destroy(WServer *server)
         surfaceRemoved(surface);
         surface->deleteLater();
     }
+}
+
+wl_global *WXWayland::global() const
+{
+    return handle()->handle()->shell_v1->global;
 }
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/kernel/wxwayland.h
+++ b/src/server/kernel/wxwayland.h
@@ -60,6 +60,7 @@ protected:
 
     void create(WServer *server) override;
     void destroy(WServer *server) override;
+    wl_global *global() const override;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquickbackend_p.h
+++ b/src/server/qtquick/private/wquickbackend_p.h
@@ -27,6 +27,7 @@ class WAYLIB_SERVER_EXPORT WQuickBackend : public WQuickWaylandServerInterface, 
 {
     Q_OBJECT
     W_DECLARE_PRIVATE(WQuickBackend)
+    Q_PROPERTY(WSocket* ownsSocket READ ownsSocket CONSTANT)
     QML_NAMED_ELEMENT(WaylandBackend)
 
 public:

--- a/src/server/qtquick/private/wquickseat.cpp
+++ b/src/server/qtquick/private/wquickseat.cpp
@@ -208,6 +208,7 @@ void WQuickSeat::create()
     W_D(WQuickSeat);
     Q_ASSERT(!d->name.isEmpty());
     d->seat = server()->attach<WSeat>(d->name.toUtf8());
+    d->seat->setOwnsSocket(ownsSocket());
     if (d->eventFilter)
         d->seat->setEventFilter(d->eventFilter);
     if (d->keyboardFocus)
@@ -223,6 +224,13 @@ void WQuickSeat::polish()
         d->seat->setCursor(d->cursor);
         d->updateCursorMap();
     }
+}
+
+void WQuickSeat::ownsSocketChange()
+{
+    W_D(WQuickSeat);
+    if (d->seat)
+        d->seat->setOwnsSocket(ownsSocket());
 }
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquickseat_p.h
+++ b/src/server/qtquick/private/wquickseat_p.h
@@ -62,6 +62,7 @@ private:
 
     void create() override;
     void polish() override;
+    void ownsSocketChange() override;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquicksocket_p.h
+++ b/src/server/qtquick/private/wquicksocket_p.h
@@ -34,6 +34,7 @@ class WAYLIB_SERVER_EXPORT WQuickSocket : public WQuickWaylandServerInterface
     Q_PROPERTY(QString socketFile READ socketFile WRITE setSocketFile NOTIFY socketFileChanged FINAL)
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged FINAL)
     Q_PROPERTY(bool freezeClientWhenDisable READ freezeClientWhenDisable WRITE setFreezeClientWhenDisable NOTIFY freezeClientWhenDisableChanged FINAL)
+    Q_PROPERTY(WSocket* ownsSocket READ ownsSocket CONSTANT)
     QML_NAMED_ELEMENT(WaylandSocket)
     QML_ATTACHED(WQuickSocketAttached)
 

--- a/src/server/qtquick/private/wquickxdgdecorationmanager_p.h
+++ b/src/server/qtquick/private/wquickxdgdecorationmanager_p.h
@@ -16,6 +16,7 @@ class WAYLIB_SERVER_EXPORT WQuickXdgDecorationManager : public WQuickWaylandServ
     Q_OBJECT
     W_DECLARE_PRIVATE(WQuickXdgDecorationManager)
     Q_PROPERTY(DecorationMode mode READ mode WRITE setMode NOTIFY modeChanged)
+    Q_PROPERTY(WSocket* ownsSocket READ ownsSocket CONSTANT)
     QML_NAMED_ELEMENT(XdgDecorationManager)
 
 public:

--- a/src/server/qtquick/private/wquickxdgshell.cpp
+++ b/src/server/qtquick/private/wquickxdgshell.cpp
@@ -73,7 +73,15 @@ void WQuickXdgShell::create()
     W_D(WQuickXdgShell);
 
     d->xdgShell = server()->attach<XdgShell>(this);
+    d->xdgShell->setOwnsSocket(ownsSocket());
     WQuickWaylandServerInterface::polish();
+}
+
+void WQuickXdgShell::ownsSocketChange()
+{
+    W_D(WQuickXdgShell);
+    if (d->xdgShell)
+        d->xdgShell->setOwnsSocket(ownsSocket());
 }
 
 WXdgSurfaceItem::WXdgSurfaceItem(QQuickItem *parent)

--- a/src/server/qtquick/private/wquickxdgshell_p.h
+++ b/src/server/qtquick/private/wquickxdgshell_p.h
@@ -37,6 +37,7 @@ Q_SIGNALS:
 
 private:
     void create() override;
+    void ownsSocketChange() override;
 };
 
 class WAYLIB_SERVER_EXPORT WXdgSurfaceItem : public WSurfaceItem

--- a/src/server/qtquick/private/wquickxwayland.cpp
+++ b/src/server/qtquick/private/wquickxwayland.cpp
@@ -182,6 +182,12 @@ void WQuickXWayland::create()
     tryCreateXWayland();
 }
 
+void WQuickXWayland::ownsSocketChange()
+{
+    if (xwayland)
+        xwayland->setOwnsSocket(ownsSocket());
+}
+
 void WQuickXWayland::tryCreateXWayland()
 {
     if (!m_compositor)
@@ -190,6 +196,7 @@ void WQuickXWayland::tryCreateXWayland()
     Q_ASSERT(!xwayland);
 
     xwayland = server()->attach<XWayland>(this);
+    xwayland->setOwnsSocket(ownsSocket());
     connect(xwayland->handle(), &QWXWayland::ready, this, &WQuickXWayland::ready);
 
     Q_EMIT displayNameChanged();

--- a/src/server/qtquick/private/wquickxwayland_p.h
+++ b/src/server/qtquick/private/wquickxwayland_p.h
@@ -26,6 +26,7 @@ class WAYLIB_SERVER_EXPORT WXWaylandShellV1 : public WQuickWaylandServerInterfac
 {
     Q_OBJECT
     Q_PROPERTY(QW_NAMESPACE::QWXWaylandShellV1* shell READ shell NOTIFY shellChanged FINAL)
+    Q_PROPERTY(WSocket* ownsSocket READ ownsSocket CONSTANT)
     QML_NAMED_ELEMENT(XWaylandShellV1)
 
 public:
@@ -86,6 +87,7 @@ private:
     friend class XWayland;
 
     void create() override;
+    void ownsSocketChange() override;
     void tryCreateXWayland();
     void onIsToplevelChanged();
     void addSurface(WXWaylandSurface *surface);

--- a/src/server/qtquick/private/wwaylandcompositor_p.h
+++ b/src/server/qtquick/private/wwaylandcompositor_p.h
@@ -32,6 +32,7 @@ class WAYLIB_SERVER_EXPORT WWaylandCompositor : public WQuickWaylandServerInterf
     Q_PROPERTY(QW_NAMESPACE::QWAllocator *allocator READ allocator NOTIFY allocatorChanged)
     Q_PROPERTY(QW_NAMESPACE::QWCompositor *compositor READ compositor NOTIFY compositorChanged)
     Q_PROPERTY(QW_NAMESPACE::QWSubcompositor *subcompositor READ subcompositor NOTIFY subcompositorChanged)
+    Q_PROPERTY(WSocket* ownsSocket READ ownsSocket CONSTANT)
     QML_NAMED_ELEMENT(WaylandCompositor)
 
 public:

--- a/src/server/qtquick/wquickwaylandserver.cpp
+++ b/src/server/qtquick/wquickwaylandserver.cpp
@@ -14,6 +14,7 @@ public:
     Q_DECLARE_PUBLIC(WQuickWaylandServerInterface)
 
     bool isPolished = false;
+    WSocket *ownsSocket = nullptr;
 };
 
 class WQuickWaylandServerPrivate : public WServerPrivate
@@ -163,6 +164,23 @@ bool WQuickWaylandServerInterface::isPolished() const
     return d->isPolished;
 }
 
+WSocket *WQuickWaylandServerInterface::ownsSocket() const
+{
+    Q_D(const WQuickWaylandServerInterface);
+    return d->ownsSocket;
+}
+
+void WQuickWaylandServerInterface::setOwnsSocket(WSocket *socket)
+{
+    Q_D(WQuickWaylandServerInterface);
+    if (d->ownsSocket == socket)
+        return;
+    d->ownsSocket = socket;
+    Q_EMIT ownsSocketChanged();
+
+    ownsSocketChange();
+}
+
 void WQuickWaylandServerInterface::create()
 {
     Q_EMIT beforeCreate();
@@ -173,6 +191,11 @@ void WQuickWaylandServerInterface::polish()
     Q_D(WQuickWaylandServerInterface);
     d->isPolished = true;
     Q_EMIT afterPolish();
+}
+
+void WQuickWaylandServerInterface::ownsSocketChange()
+{
+
 }
 
 WQuickWaylandServer::WQuickWaylandServer(QObject *parent)

--- a/src/server/qtquick/wquickwaylandserver.h
+++ b/src/server/qtquick/wquickwaylandserver.h
@@ -7,6 +7,8 @@
 #include <QQmlParserStatus>
 #include <QQmlEngine>
 
+Q_MOC_INCLUDE(<wsocket.h>)
+
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WQuickWaylandServer;
@@ -17,6 +19,7 @@ class WAYLIB_SERVER_EXPORT WQuickWaylandServerInterface : public QObject
     Q_DECLARE_PRIVATE(WQuickWaylandServerInterface)
     QML_NAMED_ELEMENT(WaylandServerInterface)
     Q_PROPERTY(bool polished READ isPolished NOTIFY afterPolish)
+    Q_PROPERTY(WSocket* ownsSocket READ ownsSocket WRITE setOwnsSocket NOTIFY ownsSocketChanged)
 
 public:
     explicit WQuickWaylandServerInterface(QObject *parent = nullptr);
@@ -24,9 +27,13 @@ public:
     WQuickWaylandServer *server() const;
     bool isPolished() const;
 
+    WSocket *ownsSocket() const;
+    void setOwnsSocket(WSocket *socket);
+
 Q_SIGNALS:
     void beforeCreate();
     void afterPolish();
+    void ownsSocketChanged();
 
 protected:
     friend class WQuickWaylandServer;
@@ -34,6 +41,7 @@ protected:
 
     virtual void create();
     virtual void polish();
+    virtual void ownsSocketChange();
 };
 
 class WQuickWaylandServerPrivate;


### PR DESCRIPTION
If you want a protocol only visible in a specified socket, you can use WServerInterface::setOwnsSocket now, the WServer will ensure the WServerInterface only visible for the wl_clients connect from the wl_socket of WServerInterface::ownsSocket.