### PR TITLE
chore: remove not directly used header

### DIFF
--- a/src/server/qtquick/woutputrenderwindow.cpp
+++ b/src/server/qtquick/woutputrenderwindow.cpp
@@ -5,7 +5,6 @@
 #include "woutput.h"
 #include "woutputhelper.h"
 #include "wrenderhelper.h"
-#include "wserver.h"
 #include "wbackend.h"
 #include "woutputviewport.h"
 #include "wtools.h"


### PR DESCRIPTION
Header wserver.h is not directly used by woutputrenderwindow.cpp. Remove it to remove compile warning.

Log: remove not directly used header