### PR TITLE
feat: input method and text input v3 support

### DIFF
--- a/examples/tinywl/CMakeLists.txt
+++ b/examples/tinywl/CMakeLists.txt
@@ -11,6 +11,7 @@ if(POLICY CMP0071)
 endif()
 
 set(QML_IMPORT_PATH ${CMAKE_BINARY_DIR}/src/server/ CACHE STRING "" FORCE)
+option(START_DEMO "Start demo when boot" ON)
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(PIXMAN REQUIRED IMPORTED_TARGET pixman-1)
@@ -48,6 +49,7 @@ qt_add_qml_module(tinywl-qtquick
 target_compile_definitions(tinywl-qtquick
     PRIVATE
     SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+    $<$<BOOL:${START_DEMO}>:START_DEMO>
 )
 
 target_link_libraries(tinywl-qtquick

--- a/examples/tinywl/CMakeLists.txt
+++ b/examples/tinywl/CMakeLists.txt
@@ -44,6 +44,7 @@ qt_add_qml_module(tinywl-qtquick
         WindowDecoration.qml
         CloseAnimation.qml
         MiniDock.qml
+        InputPopupSurface.qml
 )
 
 target_compile_definitions(tinywl-qtquick

--- a/examples/tinywl/InputPopupSurface.qml
+++ b/examples/tinywl/InputPopupSurface.qml
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+import QtQuick
+import Waylib.Server
+
+InputPopupSurfaceItem {
+    required property WaylandInputPopupSurface waylandSurface
+
+    surface: waylandSurface
+
+    x: waylandSurface.pos.x
+    y: waylandSurface.pos.y
+
+    OutputLayoutItem {
+        anchors.fill: parent
+        layout: QmlHelper.layout
+
+        onEnterOutput: function(output) {
+            waylandSurface.surface.enterOutput(output);
+        }
+        onLeaveOutput: function(output) {
+            waylandSurface.surface.leaveOutput(output);
+        }
+    }
+}

--- a/examples/tinywl/Main.qml
+++ b/examples/tinywl/Main.qml
@@ -102,6 +102,18 @@ Item {
             id: decorationManager
         }
 
+        InputMethodManagerV2 {
+            id: inputMethodManagerV2
+        }
+
+        TextInputManagerV3 {
+            id: textInputManagerV3
+        }
+
+        VirtualKeyboardManagerV1 {
+            id: virtualKeyboardManagerV1
+        }
+
         XWayland {
             compositor: compositor.compositor
             seat: seat0.seat
@@ -117,6 +129,22 @@ Item {
                     return prop.waylandSurface === surface
                 })
             }
+        }
+    }
+
+    InputMethodHelper {
+        id: inputMethodHelperSeat0
+        seat: seat0
+        textInputManagerV3: textInputManagerV3
+        inputMethodManagerV2: inputMethodManagerV2
+        virtualKeyboardManagerV1: virtualKeyboardManagerV1
+        onInputPopupSurfaceV2Added: function (surface) {
+            QmlHelper.inputPopupSurfaceManager.add({ waylandSurface: surface })
+        }
+        onInputPopupSurfaceV2Removed: function (surface) {
+            QmlHelper.inputPopupSurfaceManager.removeIf(function (prop) {
+                return prop.waylandSurface === surface
+            })
         }
     }
 
@@ -172,11 +200,13 @@ Item {
                 StackWorkspace {
                     visible: topbar.currentIndex === 0
                     anchors.fill: parent
+                    activeFocusItem: renderWindow.activeFocusItem
                 }
 
                 TiledWorkspace {
                     visible: topbar.currentIndex === 1
                     anchors.fill: parent
+                    activeFocusItem: renderWindow.activeFocusItem
                 }
             }
         }

--- a/examples/tinywl/QmlHelper.qml
+++ b/examples/tinywl/QmlHelper.qml
@@ -12,6 +12,7 @@ Item {
     property DynamicCreator xdgSurfaceManager: xdgSurfaceManager
     property DynamicCreator layerSurfaceManager: layerSurfaceManager
     property DynamicCreator xwaylandSurfaceManager: xwaylandSurfaceManager
+    property DynamicCreator inputPopupSurfaceManager: inputPopupSurfaceManager
 
     function printStructureObject(obj) {
         var json = ""
@@ -78,6 +79,19 @@ Item {
 
         onObjectRemoved: function(delegate, obj, properties) {
             console.info(`X11 surface item ${obj} is removed, it's create from delegate ${delegate} with initial properties:`,
+                         `\n${printStructureObject(properties)}`)
+        }
+    }
+
+    DynamicCreator {
+        id: inputPopupSurfaceManager
+        onObjectAdded: function (delegate, obj, properties) {
+            console.info(`New input popup surface item ${obj} from delegate ${delegate} with initial properties:`,
+                         `\n${printStructureObject(properties)}`)
+        }
+
+        onObjectRemoved: function (delegate, obj, properties) {
+            console.info(`Input popup surface item ${obj} is removed, it's create from delegate ${delegate} with initial properties:`,
                          `\n${printStructureObject(properties)}`)
         }
     }

--- a/examples/tinywl/StackWorkspace.qml
+++ b/examples/tinywl/StackWorkspace.qml
@@ -8,7 +8,7 @@ import Tinywl
 
 Item {
     id: root
-
+    required property Item activeFocusItem
     function getSurfaceItemFromWaylandSurface(surface) {
         let finder = function(props) {
             if (props.waylandSurface === surface)
@@ -233,6 +233,17 @@ Item {
                     Helper.onSurfaceLeaveOutput(waylandSurface, surface, output)
                 }
             }
+        }
+    }
+
+    DynamicCreatorComponent {
+        id: inputPopupComponent
+        creator: QmlHelper.inputPopupSurfaceManager
+
+        InputPopupSurface {
+            id: inputPopupSurface
+            waylandSurface: waylandSurface
+            parent: root.activeFocusItem
         }
     }
 }

--- a/examples/tinywl/TiledWorkspace.qml
+++ b/examples/tinywl/TiledWorkspace.qml
@@ -8,7 +8,7 @@ import Waylib.Server
 
 Item {
     id: root
-
+    required property Item activeFocusItem
     function getXdgSurfaceFromWaylandSurface(surface) {
         let finder = function(props) {
             if (props.waylandSurface === surface)
@@ -186,6 +186,17 @@ Item {
         LayerSurface {
             id: layerSurface
             creator: layerComponent
+        }
+    }
+
+    DynamicCreatorComponent {
+        id: inputPopupComponent
+        creator: QmlHelper.inputPopupSurfaceManager
+
+        InputPopupSurface {
+            id: inputPopupSurface
+            waylandSurface: waylandSurface
+            parent: root.activeFocusItem
         }
     }
 }

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -292,6 +292,7 @@ void Helper::cancelMoveResize(WSurfaceItem *shell)
 
 bool Helper::startDemoClient(const QString &socket)
 {
+#ifdef START_DEMO
     QProcess waylandClientDemo;
 
     waylandClientDemo.setProgram("qml");
@@ -302,7 +303,7 @@ bool Helper::startDemoClient(const QString &socket)
 
     waylandClientDemo.setProcessEnvironment(env);
     return waylandClientDemo.startDetached();
-
+#endif
     return false;
 }
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -90,6 +90,10 @@ set(QTQUICK_SOURCES
     qtquick/private/wquickxdgdecorationmanager.cpp
     qtquick/private/wquickcursorshape.cpp
     qtquick/private/wquicklayershell.cpp
+    qtquick/private/wquicktextinputv3.cpp
+    qtquick/private/wquickinputmethodv2.cpp
+    qtquick/private/wquickvirtualkeyboardv1.cpp
+    qtquick/private/winputmethodhelper.cpp
 )
 
 set(UTILS_SOURCES
@@ -173,6 +177,10 @@ set(PRIVATE_HEADERS
     qtquick/private/wquickcursorshape_p.h
     qtquick/private/wquicktextureproxy_p.h
     qtquick/private/wquicklayershell_p.h
+    qtquick/private/wquicktextinputv3_p.h
+    qtquick/private/wquickinputmethodv2_p.h
+    qtquick/private/wquickvirtualkeyboardv1_p.h
+    qtquick/private/winputmethodhelper_p.h
 )
 
 if(NOT DISABLE_XWAYLAND)

--- a/src/server/kernel/wseat.cpp
+++ b/src/server/kernel/wseat.cpp
@@ -475,6 +475,11 @@ QWSeat *WSeat::handle() const
     return d_func()->handle();
 }
 
+wlr_seat *WSeat::nativeHandle() const
+{
+    return d_func()->nativeHandle();
+}
+
 QString WSeat::name() const
 {
     return d_func()->name;

--- a/src/server/kernel/wseat.cpp
+++ b/src/server/kernel/wseat.cpp
@@ -241,7 +241,7 @@ public:
         if (!keyboardFocusSurface())
             return false;
 
-        this->handle()->setKeyboard(qobject_cast<QWKeyboard*>(device->handle()));
+        q_func()->setKeyboard(device);
         /* Send modifiers to the client. */
         this->handle()->keyboardNotifyKey(timestamp, keycode, state);
         return true;
@@ -251,7 +251,7 @@ public:
             return false;
 
         auto keyboard = qobject_cast<QWKeyboard*>(device->handle());
-        this->handle()->setKeyboard(keyboard);
+        q_func()->setKeyboard(device);
         /* Send modifiers to the client. */
         this->handle()->keyboardNotifyModifiers(&keyboard->handle()->modifiers);
         return true;
@@ -745,6 +745,28 @@ void WSeat::clearkeyboardFocusWindow()
 {
     W_D(WSeat);
     d->focusWindow = nullptr;
+}
+
+WInputDevice *WSeat::keyboard() const
+{
+    W_DC(WSeat);
+    auto qwKeyboard = d->handle()->getKeyboard();
+    if (qwKeyboard) {
+        auto device = WInputDevice::fromHandle(qwKeyboard);
+        Q_ASSERT(device);
+        return device;
+    } else {
+        return nullptr;
+    }
+}
+
+void WSeat::setKeyboard(WInputDevice *newKeyboard)
+{
+    W_D(WSeat);
+    if (newKeyboard == keyboard())
+        return;
+    d->handle()->setKeyboard(qobject_cast<QWKeyboard *>(newKeyboard->handle()));
+    Q_EMIT this->keyboardChanged();
 }
 
 void WSeat::notifyMotion(WCursor *cursor, WInputDevice *device, uint32_t timestamp)

--- a/src/server/kernel/wseat.h
+++ b/src/server/kernel/wseat.h
@@ -22,6 +22,7 @@ QT_END_NAMESPACE
 
 typedef uint wlr_axis_source_t;
 typedef uint wlr_button_state_t;
+struct wlr_seat;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
@@ -56,6 +57,7 @@ public:
 
     static WSeat *fromHandle(const QW_NAMESPACE::QWSeat *handle);
     QW_NAMESPACE::QWSeat *handle() const;
+    wlr_seat *nativeHandle() const;
 
     QString name() const;
 

--- a/src/server/kernel/wseat.h
+++ b/src/server/kernel/wseat.h
@@ -48,7 +48,9 @@ class WCursor;
 class WSeatPrivate;
 class WSeat : public WServerInterface, public WObject
 {
+    Q_OBJECT
     W_DECLARE_PRIVATE(WSeat)
+    Q_PROPERTY(WInputDevice* keyboard READ keyboard WRITE setKeyboard NOTIFY keyboardChanged FINAL)
 public:
     WSeat(const QString &name = QStringLiteral("seat0"));
 
@@ -80,6 +82,12 @@ public:
     void setKeyboardFocusTarget(QWindow *window);
     QWindow *focusWindow() const;
     void clearkeyboardFocusWindow();
+
+    WInputDevice *keyboard() const;
+    void setKeyboard(WInputDevice *newKeyboard);
+
+Q_SIGNALS:
+    void keyboardChanged();
 
 protected:
     friend class WOutputPrivate;

--- a/src/server/kernel/wtoplevelsurface.h
+++ b/src/server/kernel/wtoplevelsurface.h
@@ -16,6 +16,7 @@ class WToplevelSurface : public QObject
     Q_PROPERTY(bool isMaximized READ isMaximized NOTIFY maximizeChanged)
     Q_PROPERTY(bool isMinimized READ isMinimized NOTIFY minimizeChanged)
     Q_PROPERTY(WSurface* surface READ surface NOTIFY surfaceChanged)
+    Q_PROPERTY(WSurface* parentSurface READ parentSurface NOTIFY parentSurfaceChanged)
     QML_NAMED_ELEMENT(ToplevelSurface)
     QML_UNCREATABLE("Only create in C++")
 
@@ -28,6 +29,10 @@ public:
     }
 
     virtual WSurface *surface() const {
+        return nullptr;
+    }
+
+    virtual WSurface *parentSurface() const {
         return nullptr;
     }
 
@@ -81,6 +86,7 @@ Q_SIGNALS:
     void maximizeChanged();
     void minimizeChanged();
     void surfaceChanged();
+    void parentSurfaceChanged();
 
     void requestMove(WSeat *seat, quint32 serial);
     void requestResize(WSeat *seat, Qt::Edges edge, quint32 serial);

--- a/src/server/kernel/wxdgsurface.cpp
+++ b/src/server/kernel/wxdgsurface.cpp
@@ -287,15 +287,25 @@ WXdgSurface *WXdgSurface::parentXdgSurface() const
         if (!parent)
             return nullptr;
         return fromHandle(QWXdgToplevel::from(parent));
+    }
+
+    return nullptr;
+}
+
+WSurface *WXdgSurface::parentSurface() const
+{
+    W_DC(WXdgSurface);
+    if (auto toplevel = d->handle->topToplevel()) {
+        auto parent = toplevel->handle()->parent;
+        if (!parent)
+            return nullptr;
+        return WSurface::fromHandle(parent->base->surface);
     } else if (auto popup = d->handle->toPopup()) {
         auto parent = popup->handle()->parent;
         if (!parent)
             return nullptr;
-        auto xdgParent = QWXdgSurface::from(QWSurface::from(parent));
-        Q_ASSERT(xdgParent);
-        return fromHandle(xdgParent);
+        return WSurface::fromHandle(parent);
     }
-
     return nullptr;
 }
 

--- a/src/server/kernel/wxdgsurface.h
+++ b/src/server/kernel/wxdgsurface.h
@@ -40,6 +40,7 @@ public:
     static WXdgSurface *fromSurface(WSurface *surface);
 
     WXdgSurface *parentXdgSurface() const;
+    WSurface *parentSurface() const override;
 
     bool isResizeing() const;
     bool isActivated() const override;

--- a/src/server/qtquick/private/winputmethodhelper.cpp
+++ b/src/server/qtquick/private/winputmethodhelper.cpp
@@ -1,0 +1,409 @@
+// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "winputmethodhelper_p.h"
+
+#include "wquicktextinputv3_p.h"
+#include "wquickinputmethodv2_p.h"
+#include "wquickvirtualkeyboardv1_p.h"
+#include "wquickseat_p.h"
+#include "wseat.h"
+#include "wsurface.h"
+#include "wxdgsurface.h"
+
+#include <qwcompositor.h>
+#include <qwtextinputv3.h>
+#include <qwvirtualkeyboardv1.h>
+#include <qwseat.h>
+
+#include <QLoggingCategory>
+#include <QQmlInfo>
+
+extern "C" {
+#define static
+#include <wlr/types/wlr_compositor.h>
+#undef static
+#include <wlr/types/wlr_text_input_v3.h>
+#define delete delete_c
+#include <wlr/types/wlr_input_method_v2.h>
+#undef delete
+#include <wlr/types/wlr_seat.h>
+}
+
+QW_USE_NAMESPACE
+WAYLIB_SERVER_BEGIN_NAMESPACE
+Q_LOGGING_CATEGORY(qLcInputMethod, "waylib.server.im", QtInfoMsg)
+// TODO: Provide customization and a more sensible policy for placing input popup.
+static constexpr int InputPopupTopMargin = 2;
+
+struct GrabHandlerArg {
+    const WInputMethodHelper *const helper;
+    const WQuickInputMethodKeyboardGrabV2 * grab;
+};
+
+static inline void handleKey(struct wlr_seat_keyboard_grab *grab, uint32_t time_msec, uint32_t key, uint32_t state)
+{
+    auto arg = reinterpret_cast<GrabHandlerArg*>(grab->data);
+    for (auto vk: arg->helper->virtualKeyboardManagerV1()->virtualKeyboards()) {
+        if (wlr_keyboard_from_input_device(vk->keyboard()->handle()->handle()) == grab->seat->keyboard_state.keyboard) {
+            grab->seat->keyboard_state.default_grab->interface->key(grab, time_msec, key, state);
+            return;
+        }
+    }
+    arg->grab->handle()->sendKey(time_msec, key, state);
+}
+
+static inline void handleModifiers(struct wlr_seat_keyboard_grab *grab, const struct wlr_keyboard_modifiers *modifiers)
+{
+    auto arg = reinterpret_cast<GrabHandlerArg*>(grab->data);
+    for (auto vk: arg->helper->virtualKeyboardManagerV1()->virtualKeyboards()) {
+        if (wlr_keyboard_from_input_device(vk->keyboard()->handle()->handle()) == grab->seat->keyboard_state.keyboard) {
+            grab->seat->keyboard_state.default_grab->interface->modifiers(grab, modifiers);
+            return;
+        }
+    }
+    arg->grab->handle()->sendModifiers(const_cast<wlr_keyboard_modifiers*>(modifiers));
+}
+
+class WInputMethodHelperPrivate : public WObjectPrivate
+{
+    W_DECLARE_PUBLIC(WInputMethodHelper)
+public:
+    explicit WInputMethodHelperPrivate(WInputMethodHelper *qq)
+        : WObjectPrivate(qq)
+        , handlerArg({.helper = qq})
+    {}
+
+    WQuickSeat *seat;
+    WQuickInputMethodManagerV2 *inputMethodManagerV2;
+    WQuickTextInputManagerV3 *textInputManagerV3;
+    WQuickVirtualKeyboardManagerV1 *virtualKeyboardManagerV1;
+    WQuickTextInputV3 *activeTextInputV3;
+    WQuickInputMethodV2 *inputMethodV2;
+    QList<WInputPopupV2 *> popupSurfaces;
+
+    wlr_seat_keyboard_grab keyboardGrab;
+    wlr_keyboard_grab_interface grabInterface;
+    GrabHandlerArg handlerArg;
+};
+
+WInputMethodHelper::WInputMethodHelper(QObject *parent)
+    : QObject(parent)
+    , WObject(*new WInputMethodHelperPrivate(this))
+{ }
+
+WQuickSeat *WInputMethodHelper::seat() const
+{
+    W_DC(WInputMethodHelper);
+    return d->seat;
+}
+
+WQuickTextInputManagerV3 *WInputMethodHelper::textInputManagerV3() const
+{
+    W_DC(WInputMethodHelper);
+    return d->textInputManagerV3;
+}
+
+void WInputMethodHelper::setTextInputManagerV3(WQuickTextInputManagerV3 *textInputManagerV3)
+{
+    W_D(WInputMethodHelper);
+    if (d->textInputManagerV3) {
+        qmlWarning(this) << "Trying to set text input manager v3 for input method helper twice. Ignore this request";
+        return;
+    }
+    d->textInputManagerV3 = textInputManagerV3;
+    if (textInputManagerV3) {
+        connect(d->textInputManagerV3, &WQuickTextInputManagerV3::newTextInput, this, &WInputMethodHelper::onNewTextInputV3);
+    }
+}
+
+WQuickInputMethodManagerV2 *WInputMethodHelper::inputMethodManagerV2() const
+{
+    W_DC(WInputMethodHelper);
+    return d->inputMethodManagerV2;
+}
+
+void WInputMethodHelper::setInputMethodManagerV2(WQuickInputMethodManagerV2 *inputMethodManagerV2)
+{
+    W_D(WInputMethodHelper);
+    if (d->inputMethodManagerV2) {
+        qmlWarning(this) << "Trying to set input method manager v2 for input method helper twice. Ignore this request.";
+        return;
+    }
+    d->inputMethodManagerV2 = inputMethodManagerV2;
+    if (inputMethodManagerV2) {
+        connect(d->inputMethodManagerV2, &WQuickInputMethodManagerV2::newInputMethod, this, &WInputMethodHelper::onNewInputMethodV2);
+    }
+}
+
+WQuickVirtualKeyboardManagerV1 *WInputMethodHelper::virtualKeyboardManagerV1() const
+{
+    W_DC(WInputMethodHelper);
+    return d->virtualKeyboardManagerV1;
+}
+
+void WInputMethodHelper::setVirtualKeyboardManagerV1(
+    WQuickVirtualKeyboardManagerV1 *virtualKeyboardManagerV1)
+{
+    W_D(WInputMethodHelper);
+    if (d->virtualKeyboardManagerV1) {
+        qmlWarning(this) << "Trying to set virtual keyboard manager v1 for input method helper twice. Ignore this request.";
+        return;
+    }
+    d->virtualKeyboardManagerV1 = virtualKeyboardManagerV1;
+    if (virtualKeyboardManagerV1) {
+        connect(d->virtualKeyboardManagerV1, &WQuickVirtualKeyboardManagerV1::newVirtualKeyboard, this, &WInputMethodHelper::onNewVirtualKeyboardV1);
+    }
+}
+
+WQuickTextInputV3 *WInputMethodHelper::activeTextInputV3() const
+{
+    W_DC(WInputMethodHelper);
+    return d->activeTextInputV3;
+}
+
+void WInputMethodHelper::setActiveTextInputV3(WQuickTextInputV3 *newActiveTextInputV3)
+{
+    W_D(WInputMethodHelper);
+    if (d->activeTextInputV3 != newActiveTextInputV3) {
+        d->activeTextInputV3 = newActiveTextInputV3;
+        Q_EMIT this->activeTextInputV3Changed(newActiveTextInputV3);
+    }
+}
+
+WQuickInputMethodV2 *WInputMethodHelper::inputMethodV2() const
+{
+    W_DC(WInputMethodHelper);
+    return d->inputMethodV2;
+}
+
+void WInputMethodHelper::setInputMethodV2(WQuickInputMethodV2 *newInputMethodV2)
+{
+    W_D(WInputMethodHelper);
+    if (d->inputMethodV2 != newInputMethodV2) {
+        d->inputMethodV2 = newInputMethodV2;
+        Q_EMIT this->inputMethodV2Changed(newInputMethodV2);
+    }
+}
+
+void WInputMethodHelper::onNewInputMethodV2(WQuickInputMethodV2 *newInputMethod)
+{
+    if (wseat()->name() != newInputMethod->seat()->name())
+        return;
+    if (inputMethodV2()) {
+        qCWarning(qLcInputMethod) << "Ignore second creation of input on the same seat.";
+        newInputMethod->sendUnavailable();
+    }
+    setInputMethodV2(newInputMethod);
+    // Once input method is online, try to resend enter to textInput
+    onKeyboardFocusChanged();
+    connect(newInputMethod->handle(), &QWInputMethodV2::beforeDestroy, this, [this]{
+        setInputMethodV2(nullptr);
+        onKeyboardFocusLost();
+    });
+    connect(newInputMethod, &WQuickInputMethodV2::commit, this, &WInputMethodHelper::onInputMethodV2Committed);
+    connect(newInputMethod, &WQuickInputMethodV2::newKeyboardGrab, this, &WInputMethodHelper::onNewKeyboardGrab);
+    connect(newInputMethod, &WQuickInputMethodV2::newPopupSurface, this, &WInputMethodHelper::onInputPopupSurface);
+}
+
+void WInputMethodHelper::onNewTextInputV3(WQuickTextInputV3 *newTextInput)
+{
+    W_D(WInputMethodHelper);
+    // Only cares about current seat's text input
+    if (wseat()->name() == newTextInput->seat()->name()) {
+        connect(newTextInput, &WQuickTextInputV3::enable, this, [this, newTextInput]() { Q_EMIT this->onTextInputV3Enabled(newTextInput); });
+        connect(newTextInput, &WQuickTextInputV3::disable, this, [this, newTextInput]() { Q_EMIT this->onTextInputV3Disabled(newTextInput); });
+        connect(newTextInput, &WQuickTextInputV3::commit, this, [this, newTextInput]() { Q_EMIT this->onTextInputV3Committed(newTextInput); });
+        connect(newTextInput->handle(), &QWTextInputV3::beforeDestroy, this, [this, newTextInput]() { Q_EMIT this->onTextInputV3Destroyed(newTextInput); });
+    }
+}
+
+void WInputMethodHelper::onNewVirtualKeyboardV1(WQuickVirtualKeyboardV1 *newVirtualKeyboard)
+{
+    wseat()->attachInputDevice(newVirtualKeyboard->keyboard());
+    connect(newVirtualKeyboard->handle(), &QWVirtualKeyboardV1::beforeDestroy, this, [this, newVirtualKeyboard] () {
+        wseat()->detachInputDevice(newVirtualKeyboard->keyboard());
+    });
+}
+
+void WInputMethodHelper::onTextInputV3Enabled(WQuickTextInputV3 *enabledTextInputV3)
+{
+    if (activeTextInputV3())
+        return;
+    setActiveTextInputV3(enabledTextInputV3);
+    auto im = inputMethodV2();
+    if (im) {
+        im->sendActivate();
+        sendInputMethodV2State(enabledTextInputV3);
+    }
+}
+
+void WInputMethodHelper::onTextInputV3Disabled(WQuickTextInputV3 *disabledTextInputV3)
+{
+    if (activeTextInputV3() == disabledTextInputV3) {
+        setActiveTextInputV3(nullptr);
+    }
+    auto im = inputMethodV2();
+    if (im) {
+        im->sendDeactivate();
+        sendInputMethodV2State(disabledTextInputV3);
+    }
+}
+
+void WInputMethodHelper::onTextInputV3Committed(WQuickTextInputV3 *textInputV3)
+{
+    auto im = inputMethodV2();
+    if (!im)
+        return;
+    const WTextInputV3State *const current = textInputV3->state();
+    sendInputMethodV2State(textInputV3);
+}
+
+void WInputMethodHelper::onTextInputV3Destroyed(WQuickTextInputV3 *destroyedTextInputV3)
+{
+    onTextInputV3Disabled(destroyedTextInputV3);
+}
+
+void WInputMethodHelper::onInputMethodV2Committed()
+{
+    W_D(WInputMethodHelper);
+    auto inputMethod = qobject_cast<WQuickInputMethodV2 *>(sender());
+    auto textInput = activeTextInputV3();
+    if (!textInput)
+        return;
+    const WInputMethodV2State *const current = inputMethod->state();
+    if (!current->preeditStringText().isEmpty()) {
+        textInput->sendPreeditString(current->preeditStringText(), current->preeditStringCursorBegin(), current->preeditStringCursorEnd());
+    }
+    if (!current->commitString().isEmpty()) {
+        textInput->sendCommitString(current->commitString());
+    }
+    if (current->deleteSurroundingBeforeLength() || current->deleteSurroundingAfterLength()) {
+        textInput->sendDeleteSurroundingText(current->deleteSurroundingBeforeLength(), current->deleteSurroundingAfterLength());
+    }
+    textInput->sendDone();
+}
+
+void WInputMethodHelper::onKeyboardFocusChanged()
+{
+    W_D(WInputMethodHelper);
+    WSurface *keyboardFocus = seat()->keyboardFocus();
+    onKeyboardFocusLost(); // Focus change will cause a short period of lost focus
+    if (keyboardFocus) {
+        for (auto textInput : d->textInputManagerV3->textInputs()) {
+            if (keyboardFocus->handle()->handle()->resource->client == textInput->waylandClient()) {
+                textInput->sendEnter(keyboardFocus);
+            }
+        }
+    }
+}
+
+void WInputMethodHelper::sendInputMethodV2State(WQuickTextInputV3 *textInput)
+{
+    auto im = inputMethodV2();
+    if (!im) {
+        qCWarning(qLcInputMethod) << "Sending input method v2 state but input method is gone.";
+        return;
+    }
+    auto current = textInput->state();
+    if (current->features() & WTextInputV3State::SurroundingText) {
+        im->sendSurroundingText(current->surroundingText(), current->surroundingCursor(), current->surroundingAnchor());
+    }
+    im->sendTextChangeCause(current->textChangeCause());
+    if (current->features() & WTextInputV3State::ContentType) {
+        im->sendContentType(current->contentHint(), current->contentPurpose());
+    }
+    if (current->features() & WTextInputV3State::CursorRect) {
+        updateAllPopupSurfaces();
+    }
+    im->sendDone();
+}
+
+void WInputMethodHelper::onNewKeyboardGrab(WQuickInputMethodKeyboardGrabV2 *keyboardGrab)
+{
+    W_D(WInputMethodHelper);
+    keyboardGrab->setKeyboard(wseat()->keyboard());
+    connect(wseat(), &WSeat::keyboardChanged, keyboardGrab, [this, keyboardGrab](){
+        keyboardGrab->setKeyboard(wseat()->keyboard());
+    });
+
+    d->grabInterface = *wseat()->nativeHandle()->keyboard_state.grab->interface;
+    d->grabInterface.key = handleKey;
+    d->grabInterface.modifiers = handleModifiers;
+    d->keyboardGrab.seat = wseat()->nativeHandle();
+    d->handlerArg.grab = keyboardGrab;
+    d->keyboardGrab.data = &d->handlerArg;
+    d->keyboardGrab.interface = &d->grabInterface;
+    wseat()->handle()->keyboardStartGrab(&d->keyboardGrab);
+    connect(keyboardGrab->handle(), &QWInputMethodKeyboardGrabV2::beforeDestroy, this, [this, keyboardGrab](){
+        if (keyboardGrab->keyboard()) {
+            wseat()->handle()->keyboardSendModifiers(&keyboardGrab->nativeHandle()->keyboard->modifiers);
+        }
+        wseat()->handle()->keyboardEndGrab();
+    });
+}
+
+void WInputMethodHelper::onInputPopupSurface(WQuickInputPopupSurfaceV2 *popupSurface)
+{
+    W_D(WInputMethodHelper);
+    auto ti = activeTextInputV3();
+    if (!ti) {
+        qCWarning(qLcInputMethod) << "New popup surface" << popupSurface << "is discarded because there is no active textinput.";
+        return;
+    }
+    auto surface = new WInputPopupV2(popupSurface, ti->focusedSurface(), this);
+    d->popupSurfaces.append(surface);
+    Q_EMIT this->inputPopupSurfaceV2Added(surface);
+    updatePopupSurface(surface);
+    connect(popupSurface->handle(), &QWInputPopupSurfaceV2::beforeDestroy, this, [this, d, surface](){
+        Q_EMIT this->inputPopupSurfaceV2Removed(surface);
+        d->popupSurfaces.removeAll(surface);
+        surface->deleteLater();
+    });
+}
+
+void WInputMethodHelper::onKeyboardFocusLost()
+{
+    W_D(WInputMethodHelper);
+    for (auto textInput : d->textInputManagerV3->textInputs()) {
+        if (textInput->focusedSurface()) {
+            textInput->sendLeave();
+        }
+    }
+}
+
+void WInputMethodHelper::updateAllPopupSurfaces()
+{
+    for (auto popup : d_func()->popupSurfaces) {
+        updatePopupSurface(popup);
+    }
+}
+
+void WInputMethodHelper::updatePopupSurface(WInputPopupV2 *popup)
+{
+    auto ti = activeTextInputV3();
+    if (!ti)
+        return;
+    auto rect = ti->state()->cursorRect();
+    popup->handle()->sendTextInputRectangle(rect);
+    popup->move(rect.x(), rect.y() + rect.height() + InputPopupTopMargin);
+}
+
+void WInputMethodHelper::setSeat(WQuickSeat *newSeat)
+{
+    W_D(WInputMethodHelper);
+    if (d->seat) {
+        qmlWarning(this) << "Trying to set seat for input method helper twice. Ignore this request.";
+        return;
+    }
+    d->seat = newSeat;
+    if (newSeat) {
+        connect(d->seat, &WQuickSeat::keyboardFocusChanged, this, &WInputMethodHelper::onKeyboardFocusChanged);
+    }
+}
+
+WSeat *WInputMethodHelper::wseat() const
+{
+    return seat()->seat();
+}
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/winputmethodhelper_p.h
+++ b/src/server/qtquick/private/winputmethodhelper_p.h
@@ -1,0 +1,84 @@
+// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <wglobal.h>
+
+#include <QObject>
+#include <QQmlEngine>
+
+Q_MOC_INCLUDE("wquickseat_p.h")
+Q_MOC_INCLUDE("wquicktextinputv3_p.h")
+Q_MOC_INCLUDE("wquickinputmethodv2_p.h")
+Q_MOC_INCLUDE("wquickvirtualkeyboardv1_p.h")
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+class WQuickSeat;
+class WQuickTextInputManagerV3;
+class WQuickTextInputV3;
+class WQuickInputMethodManagerV2;
+class WQuickInputMethodKeyboardGrabV2;
+class WQuickInputMethodV2;
+class WQuickVirtualKeyboardManagerV1;
+class WQuickVirtualKeyboardV1;
+class WInputMethodHelperPrivate;
+class WSurface;
+class WSeat;
+class WInputPopupV2;
+class WQuickInputPopupSurfaceV2;
+class WInputMethodHelper : public QObject, public WObject
+{
+    Q_OBJECT
+    W_DECLARE_PRIVATE(WInputMethodHelper)
+    QML_NAMED_ELEMENT(InputMethodHelper)
+    Q_PROPERTY(WQuickSeat *seat READ seat WRITE setSeat FINAL REQUIRED)
+    Q_PROPERTY(WQuickTextInputManagerV3 *textInputManagerV3 READ textInputManagerV3 WRITE setTextInputManagerV3 FINAL REQUIRED)
+    Q_PROPERTY(WQuickInputMethodManagerV2 *inputMethodManagerV2 READ inputMethodManagerV2 WRITE setInputMethodManagerV2 FINAL REQUIRED)
+    Q_PROPERTY(WQuickVirtualKeyboardManagerV1 *virtualKeyboardManagerV1 READ virtualKeyboardManagerV1 WRITE setVirtualKeyboardManagerV1 FINAL REQUIRED)
+    Q_PROPERTY(WQuickTextInputV3 *activeTextInputV3 READ activeTextInputV3 WRITE setActiveTextInputV3 NOTIFY activeTextInputV3Changed FINAL)
+    Q_PROPERTY(WQuickInputMethodV2 *inputMethodV2 READ inputMethodV2 WRITE setInputMethodV2 NOTIFY inputMethodV2Changed FINAL)
+
+public:
+    explicit WInputMethodHelper(QObject *parent = nullptr);
+
+    WQuickSeat *seat() const;
+    void setSeat(WQuickSeat *newSeat);
+    WSeat *wseat() const;
+    WQuickTextInputManagerV3 *textInputManagerV3() const;
+    void setTextInputManagerV3(WQuickTextInputManagerV3 *textInputManagerV3);
+    WQuickInputMethodManagerV2 *inputMethodManagerV2() const;
+    void setInputMethodManagerV2(WQuickInputMethodManagerV2 *inputMethodManagerV2);
+    WQuickVirtualKeyboardManagerV1 *virtualKeyboardManagerV1() const;
+    void setVirtualKeyboardManagerV1(WQuickVirtualKeyboardManagerV1 *virtualKeyboardManagerV1);
+    WQuickTextInputV3 *activeTextInputV3() const;
+    void setActiveTextInputV3(WQuickTextInputV3 *newActiveTextInputV3);
+    WQuickInputMethodV2 *inputMethodV2() const;
+    void setInputMethodV2(WQuickInputMethodV2 *newInputMethodV2);
+
+Q_SIGNALS:
+    void activeTextInputV3Changed(WQuickTextInputV3 *newActiveTextInputV3);
+    void inputMethodV2Changed(WQuickInputMethodV2 *newInputMethod);
+    void inputPopupSurfaceV2Added(WInputPopupV2 *surfaceItem);
+    void inputPopupSurfaceV2Removed(WInputPopupV2 *surfaceItem);
+
+private:
+    void onNewInputMethodV2(WQuickInputMethodV2 *newInputMethod);
+    void onNewTextInputV3(WQuickTextInputV3 *newTextInput);
+    void onNewVirtualKeyboardV1(WQuickVirtualKeyboardV1 *newVirtualKeyboard);
+    void onTextInputV3Enabled(WQuickTextInputV3 *enabledTextInput);
+    void onTextInputV3Disabled(WQuickTextInputV3 *disabledTextInput);
+    void onTextInputV3Committed(WQuickTextInputV3 *textInput);
+    void onTextInputV3Destroyed(WQuickTextInputV3 *destroyedTextInput);
+    void onInputMethodV2Committed();
+    void onKeyboardFocusChanged();
+    void onNewKeyboardGrab(WQuickInputMethodKeyboardGrabV2 *keyboardGrab);
+    void onInputPopupSurface(WQuickInputPopupSurfaceV2 *popupSurface);
+    void onKeyboardFocusLost();
+
+    void sendInputMethodV2State(WQuickTextInputV3 *textInputV3);
+    void updateAllPopupSurfaces();
+    void updatePopupSurface(WInputPopupV2 *popup);
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/woutputitem_p.h
+++ b/src/server/qtquick/private/woutputitem_p.h
@@ -55,6 +55,7 @@ class QuickOutputCursor : public QObject
     Q_PROPERTY(QSizeF size READ size WRITE setSize NOTIFY sizeChanged)
     Q_PROPERTY(QRectF sourceRect READ sourceRect WRITE setSourceRect NOTIFY sourceRectChanged)
     QML_NAMED_ELEMENT(OutputCursor)
+    QML_UNCREATABLE("Only create in C++")
 
 public:
     explicit QuickOutputCursor(wlr_output_cursor *handle, QObject *parent = nullptr);

--- a/src/server/qtquick/private/wquickinputmethodv2.cpp
+++ b/src/server/qtquick/private/wquickinputmethodv2.cpp
@@ -1,0 +1,509 @@
+// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wquickinputmethodv2_p.h"
+#include "wseat.h"
+#include "winputdevice.h"
+#include "wsurface.h"
+#include "wxdgsurface.h"
+
+#include <qwcompositor.h>
+#include <qwinputmethodv2.h>
+#include <qwseat.h>
+#include <qwkeyboard.h>
+
+#include <QKeySequence>
+#include <QLoggingCategory>
+#include <QRect>
+
+extern "C" {
+#define delete delete_c
+#include <wlr/types/wlr_input_method_v2.h>
+#undef delete
+#include <wlr/types/wlr_keyboard.h>
+#define static
+#include <wlr/types/wlr_compositor.h>
+#undef static
+}
+
+QW_USE_NAMESPACE
+WAYLIB_SERVER_BEGIN_NAMESPACE
+Q_DECLARE_LOGGING_CATEGORY(qLcInputMethod)
+class WQuickInputMethodManagerV2Private : public WObjectPrivate
+{
+public:
+    explicit WQuickInputMethodManagerV2Private(WQuickInputMethodManagerV2 *qq)
+        : WObjectPrivate(qq)
+        , manager(nullptr)
+    {}
+    W_DECLARE_PUBLIC(WQuickInputMethodManagerV2)
+
+    QWInputMethodManagerV2 *manager;
+    QList<WQuickInputMethodV2 *> inputMethods;
+};
+
+WQuickInputMethodManagerV2::WQuickInputMethodManagerV2(QObject *parent) :
+    WQuickWaylandServerInterface(parent),
+    WObject(*new WQuickInputMethodManagerV2Private(this), nullptr)
+{ }
+
+void WQuickInputMethodManagerV2::create()
+{
+    W_D(WQuickInputMethodManagerV2);
+    WQuickWaylandServerInterface::create();
+    d->manager = QWInputMethodManagerV2::create(server()->handle());
+    connect(d->manager, &QWInputMethodManagerV2::inputMethod, this, [this, d] (QWInputMethodV2 *im) {
+        auto quickInputMethod = new WQuickInputMethodV2(im, this);
+        connect(quickInputMethod->handle(), &QWInputMethodV2::beforeDestroy, this, [d, quickInputMethod]() {
+            d->inputMethods.removeAll(quickInputMethod);
+            quickInputMethod->deleteLater();
+        });
+        d->inputMethods.append(quickInputMethod);
+        Q_EMIT this->newInputMethod(quickInputMethod);
+    });
+}
+
+class WQuickInputPopupSurfaceV2Private : public WObjectPrivate
+{
+public:
+    WQuickInputPopupSurfaceV2Private(QWInputPopupSurfaceV2 *h, WQuickInputPopupSurfaceV2 *qq)
+        : WObjectPrivate(qq)
+        , handle(h)
+        , popupSurface(new WSurface(h->surface(), qq))
+    { }
+
+    W_DECLARE_PUBLIC(WQuickInputPopupSurfaceV2)
+    QWInputPopupSurfaceV2 *handle;
+    WSurface *popupSurface;
+};
+
+class WQuickInputMethodKeyboardGrabV2Private : public WObjectPrivate
+{
+public:
+    WQuickInputMethodKeyboardGrabV2Private(QWInputMethodKeyboardGrabV2 *h, WQuickInputMethodKeyboardGrabV2 *qq)
+        : WObjectPrivate(qq)
+        , handle(h)
+    { }
+    W_DECLARE_PUBLIC(WQuickInputMethodKeyboardGrabV2)
+    QWInputMethodKeyboardGrabV2 *handle;
+    wlr_keyboard_modifiers modifiers;
+};
+
+class WQuickInputMethodV2Private : public WObjectPrivate
+{
+public:
+    WQuickInputMethodV2Private(QWInputMethodV2 *h, WQuickInputMethodV2 *qq)
+        : WObjectPrivate(qq)
+        , handle(h)
+        , activeKeyboardGrab(nullptr)
+        , state(new WInputMethodV2State(&h->handle()->current, qq))
+    { }
+
+    QWInputMethodV2 *handle;
+    QList<WQuickInputPopupSurfaceV2 *> popupSurfaces;
+    WQuickInputMethodKeyboardGrabV2 *activeKeyboardGrab;
+    WInputMethodV2State *const state;
+
+    W_DECLARE_PUBLIC(WQuickInputMethodV2)
+};
+
+WQuickInputMethodV2::WQuickInputMethodV2(QWInputMethodV2 *handle, QObject *parent) :
+    QObject(parent),
+    WObject(*new WQuickInputMethodV2Private(handle, this), nullptr)
+{
+    W_D(WQuickInputMethodV2);
+    connect(d->handle, &QWInputMethodV2::commit, this, &WQuickInputMethodV2::commit);
+    connect(d->handle, &QWInputMethodV2::newPopupSurface, this, [this, d](QWInputPopupSurfaceV2 *surface) {
+        auto quickPopupSurface = new WQuickInputPopupSurfaceV2(surface, this);
+        d->popupSurfaces.append(quickPopupSurface);
+        connect(quickPopupSurface->handle(), &QWInputPopupSurfaceV2::beforeDestroy, this, [d, quickPopupSurface]() {
+            d->popupSurfaces.removeAll(quickPopupSurface);
+            quickPopupSurface->deleteLater();
+        });
+        Q_EMIT this->newPopupSurface(quickPopupSurface);
+    });
+    connect(d->handle, &QWInputMethodV2::grabKeybord, this, [this, d](QWInputMethodKeyboardGrabV2 *keyboardGrab){
+        auto quickKeyboardGrab = new WQuickInputMethodKeyboardGrabV2(keyboardGrab, this);
+        d->activeKeyboardGrab = quickKeyboardGrab;
+        connect(quickKeyboardGrab->handle(), &QWInputMethodKeyboardGrabV2::beforeDestroy, this, [d, quickKeyboardGrab]() {
+            d->activeKeyboardGrab = nullptr;
+            quickKeyboardGrab->deleteLater();
+        });
+        Q_EMIT this->newKeyboardGrab(quickKeyboardGrab);
+    });
+}
+
+QList<WQuickInputPopupSurfaceV2 *> WQuickInputMethodV2::popupSurfaces() const
+{
+    W_DC(WQuickInputMethodV2);
+    return d->popupSurfaces;
+}
+
+WInputMethodV2State *WQuickInputMethodV2::state() const
+{
+    W_DC(WQuickInputMethodV2);
+    return d->state;
+}
+
+QWInputMethodV2 *WQuickInputMethodV2::handle() const
+{
+    return d_func()->handle;
+}
+
+WSeat *WQuickInputMethodV2::seat() const
+{
+    W_DC(WQuickInputMethodV2);
+    return WSeat::fromHandle(QWSeat::from(d->handle->handle()->seat));
+}
+
+void WQuickInputMethodV2::sendContentType(quint32 hint, quint32 purpose)
+{
+    W_D(WQuickInputMethodV2);
+    d->handle->sendContentType(hint, purpose);
+}
+
+void WQuickInputMethodV2::sendActivate()
+{
+    W_D(WQuickInputMethodV2);
+    d->handle->sendActivate();
+}
+
+void WQuickInputMethodV2::sendDeactivate()
+{
+    W_D(WQuickInputMethodV2);
+    d->handle->sendDeactivate();
+}
+
+void WQuickInputMethodV2::sendDone()
+{
+    W_D(WQuickInputMethodV2);
+    d->handle->sendDone();
+}
+
+void WQuickInputMethodV2::sendSurroundingText(const QString &text, quint32 cursor, quint32 anchor)
+{
+    W_D(WQuickInputMethodV2);
+    d->handle->sendSurroundingText(qPrintable(text), cursor, anchor);
+}
+
+void WQuickInputMethodV2::sendTextChangeCause(quint32 cause)
+{
+    W_D(WQuickInputMethodV2);
+    d->handle->sendTextChangeCause(cause);
+}
+
+void WQuickInputMethodV2::sendUnavailable()
+{
+    W_D(WQuickInputMethodV2);
+    d->handle->sendUnavailable();
+}
+
+void WQuickInputMethodV2::sendTextInputRectangle(const QRect &rect)
+{
+    W_D(WQuickInputMethodV2);
+    // FIXME: Just send text input rectangle to all
+    for (auto popupSurface : d->popupSurfaces) {
+        popupSurface->sendTextInputRectangle(rect);
+    }
+}
+
+WQuickInputPopupSurfaceV2::WQuickInputPopupSurfaceV2(QWInputPopupSurfaceV2 *handle, QObject *parent) :
+    QObject(parent),
+    WObject(*new WQuickInputPopupSurfaceV2Private(handle, this), nullptr)
+{ }
+
+WSurface *WQuickInputPopupSurfaceV2::surface() const
+{
+    W_DC(WQuickInputPopupSurfaceV2);
+    return d->popupSurface;
+}
+
+QWInputPopupSurfaceV2 *WQuickInputPopupSurfaceV2::handle() const
+{
+    return d_func()->handle;
+}
+
+
+void WQuickInputPopupSurfaceV2::sendTextInputRectangle(const QRect &sbox)
+{
+    W_D(WQuickInputPopupSurfaceV2);
+    d->handle->send_text_input_rectangle(sbox);
+}
+
+WQuickInputMethodKeyboardGrabV2::WQuickInputMethodKeyboardGrabV2(QWInputMethodKeyboardGrabV2 *handle, QObject *parent):
+    QObject(parent),
+    WObject(*new WQuickInputMethodKeyboardGrabV2Private(handle, this), nullptr)
+{ }
+
+QWInputMethodKeyboardGrabV2 *WQuickInputMethodKeyboardGrabV2::handle() const
+{
+    W_DC(WQuickInputMethodKeyboardGrabV2);
+    return d->handle;
+}
+
+wlr_input_method_keyboard_grab_v2 *WQuickInputMethodKeyboardGrabV2::nativeHandle() const
+{
+    W_DC(WQuickInputMethodKeyboardGrabV2);
+    return d->handle->handle();
+}
+
+WQuickInputMethodKeyboardGrabV2::KeyboardModifiers WQuickInputMethodKeyboardGrabV2::depressedModifiers() const
+{
+    W_DC(WQuickInputMethodKeyboardGrabV2);
+    return {d->modifiers.depressed};
+}
+
+WQuickInputMethodKeyboardGrabV2::KeyboardModifiers WQuickInputMethodKeyboardGrabV2::latchedModifiers() const
+{
+    W_DC(WQuickInputMethodKeyboardGrabV2);
+    return {d->modifiers.latched};
+}
+
+WQuickInputMethodKeyboardGrabV2::KeyboardModifiers WQuickInputMethodKeyboardGrabV2::lockedModifiers() const
+{
+    W_DC(WQuickInputMethodKeyboardGrabV2);
+    return {d->modifiers.locked};
+}
+
+WQuickInputMethodKeyboardGrabV2::KeyboardModifiers WQuickInputMethodKeyboardGrabV2::group() const
+{
+    W_DC(WQuickInputMethodKeyboardGrabV2);
+    return {d->modifiers.group};
+}
+
+void WQuickInputMethodKeyboardGrabV2::setDepressedModifiers(KeyboardModifiers modifiers)
+{
+    W_D(WQuickInputMethodKeyboardGrabV2);
+    d->modifiers.depressed = modifiers;
+}
+
+void WQuickInputMethodKeyboardGrabV2::setLatchedModifiers(KeyboardModifiers modifiers)
+{
+    W_D(WQuickInputMethodKeyboardGrabV2);
+    d->modifiers.latched = modifiers;
+}
+
+void WQuickInputMethodKeyboardGrabV2::setLockedModifiers(KeyboardModifiers modifiers)
+{
+    W_D(WQuickInputMethodKeyboardGrabV2);
+    d->modifiers.locked = modifiers;
+}
+
+void WQuickInputMethodKeyboardGrabV2::setGroup(KeyboardModifiers group)
+{
+    W_D(WQuickInputMethodKeyboardGrabV2);
+    d->modifiers.group = group;
+}
+
+WInputDevice *WQuickInputMethodKeyboardGrabV2::keyboard() const
+{
+    W_DC(WQuickInputMethodKeyboardGrabV2);
+    if (d->handle->handle()->keyboard) {
+        return WInputDevice::fromHandle(QWInputDevice::from(&d->handle->handle()->keyboard->base));
+    } else {
+        return nullptr;
+    }
+}
+
+void WQuickInputMethodKeyboardGrabV2::sendKey(quint32 time, Qt::Key key, quint32 state)
+{
+    W_D(WQuickInputMethodKeyboardGrabV2);
+    d->handle->sendKey(time, key, state);
+}
+
+void WQuickInputMethodKeyboardGrabV2::sendModifiers()
+{
+    W_D(WQuickInputMethodKeyboardGrabV2);
+    d->handle->sendModifiers(&d->modifiers);
+}
+
+void WQuickInputMethodKeyboardGrabV2::setKeyboard(WInputDevice *keyboard)
+{
+    W_D(WQuickInputMethodKeyboardGrabV2);
+    if (keyboard) {
+        auto qwKeyboard = qobject_cast<QWKeyboard *>(keyboard->handle());
+        d->handle->setKeyboard(qwKeyboard);
+    } else {
+        d->handle->setKeyboard(nullptr);
+    }
+}
+
+class WInputMethodV2StatePrivate : public WObjectPrivate
+{
+    W_DECLARE_PUBLIC(WInputMethodV2State)
+public:
+    WInputMethodV2StatePrivate(wlr_input_method_v2_state *h, WInputMethodV2State *qq)
+        : WObjectPrivate(qq)
+        , handle(h)
+    {}
+    wlr_input_method_v2_state *const handle;
+};
+
+QString WInputMethodV2State::commitString() const
+{
+    W_DC(WInputMethodV2State);
+    return d->handle->commit_text;
+}
+
+quint32 WInputMethodV2State::deleteSurroundingBeforeLength() const
+{
+    W_DC(WInputMethodV2State);
+    return d->handle->delete_c.before_length;
+}
+
+quint32 WInputMethodV2State::deleteSurroundingAfterLength() const
+{
+    W_DC(WInputMethodV2State);
+    return d->handle->delete_c.after_length;
+}
+
+QString WInputMethodV2State::preeditStringText() const
+{
+    W_DC(WInputMethodV2State);
+    return d->handle->preedit.text;
+}
+
+qint32 WInputMethodV2State::preeditStringCursorBegin() const
+{
+    W_DC(WInputMethodV2State);
+    return d->handle->preedit.cursor_begin;
+}
+
+qint32 WInputMethodV2State::preeditStringCursorEnd() const
+{
+    W_DC(WInputMethodV2State);
+    return d->handle->preedit.cursor_end;
+}
+
+WInputMethodV2State::WInputMethodV2State(wlr_input_method_v2_state *handle, QObject *parent)
+    : QObject(parent)
+    , WObject(*new WInputMethodV2StatePrivate(handle, this))
+{}
+
+class WInputPopupSurfacePrivate : public WObjectPrivate
+{
+public:
+    W_DECLARE_PUBLIC(WInputPopupV2)
+    explicit WInputPopupSurfacePrivate(WQuickInputPopupSurfaceV2 *surface, WSurface *parentSurface, WInputPopupV2 *qq)
+        : WObjectPrivate(qq)
+        , handle(surface)
+        , parent(parentSurface)
+    { }
+
+    QSize size() const
+    {
+        return {handle->surface()->handle()->handle()->current.width, handle->surface()->handle()->handle()->current.height};
+    }
+
+    WQuickInputPopupSurfaceV2 *handle;
+    QPointF pos;
+    WSurface *const parent;
+};
+
+WInputPopupV2::WInputPopupV2(WQuickInputPopupSurfaceV2 *surface, WSurface *parentSurface, QObject *parent)
+    : WToplevelSurface(parent)
+    , WObject(*new WInputPopupSurfacePrivate(surface, parentSurface, this))
+{ }
+
+bool WInputPopupV2::doesNotAcceptFocus() const
+{
+    return true;
+}
+
+WSurface *WInputPopupV2::surface() const
+{
+    W_DC(WInputPopupSurface);
+    return d->handle->surface();
+}
+
+WQuickInputPopupSurfaceV2 *WInputPopupV2::handle() const
+{
+    return d_func()->handle;
+}
+
+QWInputPopupSurfaceV2 *WInputPopupV2::qwHandle() const
+{
+    return d_func()->handle->handle();
+}
+
+bool WInputPopupV2::isActivated() const
+{
+    return true;
+}
+
+QRect WInputPopupV2::getContentGeometry() const
+{
+    return {0, 0, d_func()->size().width(), d_func()->size().height()};
+}
+
+QPointF WInputPopupV2::pos() const
+{
+    return d_func()->pos;
+}
+
+void WInputPopupV2::move(QPointF pos)
+{
+    W_D(WInputPopupSurface);
+    if (d->pos == pos)
+        return;
+    d->pos = pos;
+    Q_EMIT this->posChanged();
+}
+
+WSurface *WInputPopupV2::parentSurface() const
+{
+    return d_func()->parent;
+}
+
+QSize WInputPopupV2::minSize() const
+{
+    return d_func()->size();
+}
+
+QSize WInputPopupV2::maxSize() const
+{
+    return d_func()->size();
+}
+
+bool WInputPopupV2::checkNewSize(const QSize &size)
+{
+    return size == d_func()->size();
+}
+
+WInputPopupV2Item::WInputPopupV2Item(QQuickItem *parent)
+    : WSurfaceItem(parent)
+    , m_inputPopupSurface(nullptr)
+{
+    connect(m_inputPopupSurface, &WInputPopupV2::posChanged, this, &WInputPopupV2Item::implicitPositionChanged);
+}
+
+WInputPopupV2 *WInputPopupV2Item::surface() const
+{
+    return m_inputPopupSurface;
+}
+
+void WInputPopupV2Item::setSurface(WInputPopupV2 *surface)
+{
+    if (m_inputPopupSurface == surface)
+        return;
+    m_inputPopupSurface = surface;
+    WSurfaceItem::setSurface(surface ? surface->surface() : nullptr);
+    Q_EMIT this->surfaceChanged();
+}
+
+QPointF WInputPopupV2Item::implicitPosition() const
+{
+    return m_inputPopupSurface->pos();
+}
+
+QSize WInputPopupV2Item::minimumSize() const
+{
+    return m_inputPopupSurface->minSize();
+}
+
+QSize WInputPopupV2Item::maximumSize() const
+{
+    return m_inputPopupSurface->maxSize();
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquickinputmethodv2_p.h
+++ b/src/server/qtquick/private/wquickinputmethodv2_p.h
@@ -1,0 +1,243 @@
+// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <wglobal.h>
+#include <wquickwaylandserver.h>
+#include <wtoplevelsurface.h>
+#include <wsurfaceitem.h>
+
+#include <qwglobal.h>
+#include <qwinputmethodv2.h>
+
+#include <QObject>
+#include <QQmlEngine>
+
+Q_MOC_INCLUDE("wquicktextinputv3_p.h")
+Q_MOC_INCLUDE("wsurface.h")
+
+struct wlr_input_method_v2_state;
+QW_BEGIN_NAMESPACE
+class QWInputMethodV2;
+class QWInputPopupSurfaceV2;
+class QWInputMethodKeyboardGrabV2;
+QW_END_NAMESPACE
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+class WQuickInputPopupSurfaceV2Private;
+class WQuickInputMethodKeyboardGrabV2Private;
+class WQuickInputMethodV2Private;
+class WInputDevice;
+class WSeat;
+class WQuickInputMethodV2;
+class WQuickInputMethodManagerV2Private;
+class WQuickTextInputV3;
+class WSurface;
+
+class WQuickInputMethodManagerV2 : public WQuickWaylandServerInterface, public WObject
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(InputMethodManagerV2)
+    W_DECLARE_PRIVATE(WQuickInputMethodManagerV2)
+
+public:
+    explicit WQuickInputMethodManagerV2(QObject *parent = nullptr);
+
+Q_SIGNALS:
+    void newInputMethod(WQuickInputMethodV2 *im);
+
+private:
+    void create() override;
+};
+
+class WQuickInputPopupSurfaceV2;
+class WInputPopupSurfacePrivate;
+class WInputPopupV2 : public WToplevelSurface, public WObject
+{
+    Q_OBJECT
+    W_DECLARE_PRIVATE(WInputPopupSurface)
+    QML_NAMED_ELEMENT(WaylandInputPopupSurface)
+    QML_UNCREATABLE("Only created in C++")
+    Q_PROPERTY(QPointF pos READ pos WRITE move NOTIFY posChanged)
+
+public:
+    WInputPopupV2(WQuickInputPopupSurfaceV2 *surface, WSurface *parentSurface, QObject *parent = nullptr);
+    WSurface *surface() const override;
+    WQuickInputPopupSurfaceV2 *handle() const;
+    QW_NAMESPACE::QWInputPopupSurfaceV2 *qwHandle() const;
+    QRect getContentGeometry() const override;
+    QSize minSize() const override;
+    QSize maxSize() const override;
+    bool doesNotAcceptFocus() const override;
+    bool isActivated() const override;
+    QPointF pos() const;
+    void move(QPointF pos);
+    inline void move(qreal x, qreal y) { move({x, y}); }
+    WSurface *parentSurface() const override;
+
+Q_SIGNALS:
+    void posChanged();
+
+public Q_SLOTS:
+    bool checkNewSize(const QSize &size) override;
+};
+
+class WInputPopupV2Item : public WSurfaceItem
+{
+    Q_OBJECT
+    Q_PROPERTY(WInputPopupV2* surface READ surface WRITE setSurface NOTIFY surfaceChanged)
+    Q_PROPERTY(QPointF implicitPosition READ implicitPosition NOTIFY implicitPositionChanged)
+    Q_PROPERTY(QSize minimumSize READ minimumSize CONSTANT FINAL)
+    Q_PROPERTY(QSize maximumSize READ maximumSize CONSTANT FINAL)
+    QML_NAMED_ELEMENT(InputPopupSurfaceItem)
+
+public:
+    explicit WInputPopupV2Item(QQuickItem *parent = nullptr);
+
+    WInputPopupV2 *surface() const;
+    void setSurface(WInputPopupV2 *surface);
+    QPointF implicitPosition() const;
+    QSize minimumSize() const;
+    QSize maximumSize() const;
+
+Q_SIGNALS:
+    void surfaceChanged();
+    void implicitPositionChanged();
+
+private:
+    WInputPopupV2 *m_inputPopupSurface;
+};
+
+class WQuickInputPopupSurfaceV2 : public QObject, public WObject
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(InputPopupSurfaceV2)
+    QML_UNCREATABLE("Only created by InputMethodV2 in C++")
+    W_DECLARE_PRIVATE(WQuickInputPopupSurfaceV2)
+    Q_PROPERTY(WSurface* surface READ surface CONSTANT FINAL)
+
+public:
+    explicit WQuickInputPopupSurfaceV2(QW_NAMESPACE::QWInputPopupSurfaceV2 *handle, QObject *parent = nullptr);
+    WSurface *surface() const;
+    QW_NAMESPACE::QWInputPopupSurfaceV2 *handle() const;
+
+public Q_SLOTS:
+    void sendTextInputRectangle(const QRect &sbox);
+};
+
+class WQuickInputMethodKeyboardGrabV2 : public QObject, public WObject
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(InputMethodKeyboardGrabV2)
+    QML_UNCREATABLE("Only created by InputMethodV2 in C++")
+    W_DECLARE_PRIVATE(WQuickInputMethodKeyboardGrabV2)
+    Q_PROPERTY(KeyboardModifiers depressedModifiers READ depressedModifiers WRITE setDepressedModifiers NOTIFY depressedModifiersChanged FINAL)
+    Q_PROPERTY(KeyboardModifiers latchedModifiers READ latchedModifiers WRITE setLatchedModifiers NOTIFY latchedModifiersChanged FINAL)
+    Q_PROPERTY(KeyboardModifiers lockedModifiers READ lockedModifiers WRITE setLockedModifiers NOTIFY lockedModifiersChanged FINAL)
+    Q_PROPERTY(KeyboardModifiers group READ group WRITE setGroup NOTIFY groupChanged FINAL)
+    Q_PROPERTY(WInputDevice *keyboard READ keyboard FINAL)
+
+public:
+    enum KeyboardModifier {
+        ModifierShift = 1 << 0,
+        ModifierCaps = 1 << 1,
+        ModifierCtrl = 1 << 2,
+        ModifierAlt = 1 << 3,
+        ModifierMod2 = 1 << 4,
+        ModifierMod3 = 1 << 5,
+        ModifierLogo = 1 << 6,
+        ModifierMod5 = 1 << 7,
+    };
+    Q_FLAG(KeyboardModifier)
+    Q_DECLARE_FLAGS(KeyboardModifiers, KeyboardModifier)
+
+    explicit WQuickInputMethodKeyboardGrabV2(QW_NAMESPACE::QWInputMethodKeyboardGrabV2 *handle, QObject *parent = nullptr);
+    QW_NAMESPACE::QWInputMethodKeyboardGrabV2 *handle() const;
+    wlr_input_method_keyboard_grab_v2 *nativeHandle() const;
+
+    KeyboardModifiers depressedModifiers() const;
+    KeyboardModifiers latchedModifiers() const;
+    KeyboardModifiers lockedModifiers() const;
+    KeyboardModifiers group() const;
+    void setDepressedModifiers(KeyboardModifiers modifiers);
+    void setLatchedModifiers(KeyboardModifiers modifiers);
+    void setLockedModifiers(KeyboardModifiers modifiers);
+    void setGroup(KeyboardModifiers group);
+    WInputDevice *keyboard() const;
+
+public Q_SLOTS:
+    void sendKey(quint32 time, Qt::Key key, quint32 state);
+    void sendModifiers();
+    void setKeyboard(WInputDevice *keyboard);
+
+Q_SIGNALS:
+    void depressedModifiersChanged(KeyboardModifiers);
+    void latchedModifiersChanged(KeyboardModifiers);
+    void lockedModifiersChanged(KeyboardModifiers);
+    void groupChanged(KeyboardModifiers);
+};
+
+class WInputMethodV2StatePrivate;
+class WInputMethodV2State : public QObject, public WObject
+{
+    Q_OBJECT
+    W_DECLARE_PRIVATE(WInputMethodV2State)
+    Q_PROPERTY(QString commitString READ commitString FINAL)
+    Q_PROPERTY(quint32 deleteSurroundingBeforeLength READ deleteSurroundingBeforeLength FINAL)
+    Q_PROPERTY(quint32 deleteSurroundingAfterLength READ deleteSurroundingAfterLength FINAL)
+    Q_PROPERTY(QString preeditStringText READ preeditStringText FINAL)
+    Q_PROPERTY(qint32 preeditStringCursorBegin READ preeditStringCursorBegin FINAL)
+    Q_PROPERTY(qint32 preeditStringCursorEnd READ preeditStringCursorEnd FINAL)
+public:
+    QString commitString() const;
+    quint32 deleteSurroundingBeforeLength() const;
+    quint32 deleteSurroundingAfterLength() const;
+    QString preeditStringText() const;
+    qint32 preeditStringCursorBegin() const;
+    qint32 preeditStringCursorEnd() const;
+
+private:
+    explicit WInputMethodV2State(wlr_input_method_v2_state *handle, QObject *parent = nullptr);
+    friend class WQuickInputMethodV2Private;
+};
+
+class WQuickInputMethodV2 : public QObject, public WObject
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(InputMethodV2)
+    QML_UNCREATABLE("Only created by InputMethodManagerV2 in C++")
+    W_DECLARE_PRIVATE(WQuickInputMethodV2)
+    Q_PROPERTY(WSeat *seat READ seat CONSTANT FINAL)
+    Q_PROPERTY(QList<WQuickInputPopupSurfaceV2 *> popupSurfaces READ popupSurfaces FINAL)
+    Q_PROPERTY(WInputMethodV2State* state READ state FINAL)
+
+public:
+    WSeat *seat() const;
+    QList<WQuickInputPopupSurfaceV2 *> popupSurfaces() const;
+    WInputMethodV2State *state() const;
+    QW_NAMESPACE::QWInputMethodV2 *handle() const;
+
+public Q_SLOTS:
+    void sendContentType(quint32 hint, quint32 purpose);
+    void sendActivate();
+    void sendDeactivate();
+    void sendDone();
+    void sendSurroundingText(const QString &text, quint32 cursor, quint32 anchor);
+    void sendTextChangeCause(quint32 cause);
+    void sendUnavailable();
+    void sendTextInputRectangle(const QRect &rect);
+
+Q_SIGNALS:
+    void commit();
+    void newPopupSurface(WQuickInputPopupSurfaceV2 *surface);
+    void newKeyboardGrab(WQuickInputMethodKeyboardGrabV2 *keyboardGrab);
+
+private:
+    explicit WQuickInputMethodV2(QW_NAMESPACE::QWInputMethodV2 *handle, QObject *parent = nullptr);
+    friend class WQuickInputMethodManagerV2;
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(WQuickInputMethodKeyboardGrabV2::KeyboardModifiers)
+WAYLIB_SERVER_END_NAMESPACE
+Q_DECLARE_METATYPE(WAYLIB_SERVER_NAMESPACE::WQuickInputMethodKeyboardGrabV2::KeyboardModifiers)

--- a/src/server/qtquick/private/wquicktextinputv3.cpp
+++ b/src/server/qtquick/private/wquicktextinputv3.cpp
@@ -1,0 +1,243 @@
+// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wquicktextinputv3_p.h"
+#include "wseat.h"
+#include "wtoplevelsurface.h"
+#include "wtools.h"
+
+#include <qwcompositor.h>
+#include <qwseat.h>
+#include <qwtextinputv3.h>
+
+#include <QLoggingCategory>
+
+extern "C" {
+#include <wlr/types/wlr_text_input_v3.h>
+#define static
+#include <wlr/types/wlr_compositor.h>
+#undef static
+}
+
+QW_USE_NAMESPACE
+WAYLIB_SERVER_BEGIN_NAMESPACE
+Q_DECLARE_LOGGING_CATEGORY(qLcInputMethod)
+class WQuickTextInputManagerV3Private : public WObjectPrivate
+{
+public:
+    WQuickTextInputManagerV3Private(WQuickTextInputManagerV3 *qq) :
+        WObjectPrivate(qq),
+        manager(nullptr)
+    {}
+    W_DECLARE_PUBLIC(WQuickTextInputManagerV3)
+
+    QWTextInputManagerV3 *manager;
+    QList<WQuickTextInputV3 *> textInputs;
+};
+
+WQuickTextInputManagerV3::WQuickTextInputManagerV3(QObject *parent) :
+    WQuickWaylandServerInterface(parent),
+    WObject(*new WQuickTextInputManagerV3Private(this))
+{}
+
+QList<WQuickTextInputV3 *> WQuickTextInputManagerV3::textInputs() const
+{
+    W_DC(WQuickTextInputManagerV3);
+    return d->textInputs;
+}
+
+void WQuickTextInputManagerV3::create()
+{
+    W_D(WQuickTextInputManagerV3);
+    WQuickWaylandServerInterface::create();
+    d->manager = QWTextInputManagerV3::create(server()->handle());
+    connect(d->manager, &QWTextInputManagerV3::textInput, this, [this, d] (QWTextInputV3 *textInput) {
+        auto quickTextInput = new WQuickTextInputV3(textInput, this);
+        connect(quickTextInput->handle(), &QWTextInputV3::beforeDestroy, this, [d, quickTextInput] () {
+            d->textInputs.removeAll(quickTextInput);
+            quickTextInput->deleteLater();
+        });
+        d->textInputs.append(quickTextInput);
+        Q_EMIT this->newTextInput(quickTextInput);
+    });
+}
+
+class WQuickTextInputV3Private : public WObjectPrivate
+{
+public:
+    W_DECLARE_PUBLIC(WQuickTextInputV3)
+    WQuickTextInputV3Private(QWTextInputV3 *h, WQuickTextInputV3 *qq)
+        : WObjectPrivate(qq)
+        , handle(h)
+        , state(new WTextInputV3State(&h->handle()->current, qq))
+        , pendingState(new WTextInputV3State(&h->handle()->pending, qq))
+    { }
+
+    QWTextInputV3 *const handle;
+    WTextInputV3State *const state;
+    WTextInputV3State *const pendingState;
+
+    wl_client *waylandClient() const override
+    {
+        return handle->handle()->resource->client;
+    }
+};
+
+WQuickTextInputV3::WQuickTextInputV3(QWTextInputV3 *handle, QObject *parent) :
+    QObject(parent),
+    WObject(*new WQuickTextInputV3Private(handle, this), nullptr)
+{
+    W_D(WQuickTextInputV3);
+    connect(d->handle, &QWTextInputV3::enable, this, &WQuickTextInputV3::enable);
+    connect(d->handle, &QWTextInputV3::disable, this, &WQuickTextInputV3::disable);
+    connect(d->handle, &QWTextInputV3::commit, this, &WQuickTextInputV3::commit);
+}
+
+WSeat *WQuickTextInputV3::seat() const
+{
+    W_DC(WQuickTextInputV3);
+    return WSeat::fromHandle(QWSeat::from(d->handle->handle()->seat));
+}
+
+WTextInputV3State *WQuickTextInputV3::state() const
+{
+    W_DC(WQuickTextInputV3);
+    return d->state;
+}
+
+WTextInputV3State *WQuickTextInputV3::pendingState() const
+{
+    W_DC(WQuickTextInputV3);
+    return d->pendingState;
+}
+
+WSurface *WQuickTextInputV3::focusedSurface() const
+{
+    W_DC(WQuickTextInputV3);
+    return WSurface::fromHandle(d->handle->handle()->focused_surface);
+}
+
+wl_client *WQuickTextInputV3::waylandClient() const
+{
+    W_DC(WQuickTextInputV3);
+    return d->waylandClient();
+}
+
+QWTextInputV3 *WQuickTextInputV3::handle() const
+{
+    return d_func()->handle;
+}
+
+void WQuickTextInputV3::sendEnter(WSurface *surface)
+{
+    W_D(WQuickTextInputV3);
+    d->handle->sendEnter(surface->handle());
+}
+
+void WQuickTextInputV3::sendLeave()
+{
+    W_D(WQuickTextInputV3);
+    d->handle->sendLeave();
+}
+
+void WQuickTextInputV3::sendPreeditString(const QString &text, qint32 cursor_begin, qint32 cursor_end)
+{
+    W_D(WQuickTextInputV3);
+    d->handle->sendPreeditString(qPrintable(text), cursor_begin, cursor_end);
+}
+
+void WQuickTextInputV3::sendCommitString(const QString &text)
+{
+    W_D(WQuickTextInputV3);
+    d->handle->sendCommitString(qPrintable(text));
+}
+
+void WQuickTextInputV3::sendDeleteSurroundingText(quint32 before_length, quint32 after_length)
+{
+    W_D(WQuickTextInputV3);
+    d->handle->sendDeleteSurroundingText(before_length, after_length);
+}
+
+void WQuickTextInputV3::sendDone()
+{
+    W_D(WQuickTextInputV3);
+    d->handle->sendDone();
+}
+
+class WTextInputV3StatePrivate : public WObjectPrivate
+{
+    W_DECLARE_PUBLIC(WTextInputV3State)
+    explicit WTextInputV3StatePrivate(wlr_text_input_v3_state *h, WTextInputV3State *qq)
+        : WObjectPrivate(qq)
+        , handle(h)
+    { }
+
+    wlr_text_input_v3_state *const handle;
+};
+
+QString WTextInputV3State::surroundingText() const
+{
+    W_DC(WTextInputV3State);
+    return d->handle->surrounding.text;
+}
+
+quint32 WTextInputV3State::surroundingCursor() const
+{
+    W_DC(WTextInputV3State);
+    return d->handle->surrounding.cursor;
+}
+
+quint32 WTextInputV3State::surroundingAnchor() const
+{
+    W_DC(WTextInputV3State);
+    return d->handle->surrounding.anchor;
+}
+
+WQuickTextInputV3::ChangeCause WTextInputV3State::textChangeCause() const
+{
+    W_DC(WTextInputV3State);
+    return static_cast<WQuickTextInputV3::ChangeCause>(d->handle->text_change_cause);
+}
+
+WQuickTextInputV3::ContentHint WTextInputV3State::contentHint() const
+{
+    W_DC(WTextInputV3State);
+    return static_cast<WQuickTextInputV3::ContentHint>(d->handle->content_type.hint);
+}
+
+WQuickTextInputV3::ContentPurpose WTextInputV3State::contentPurpose() const
+{
+    W_DC(WTextInputV3State);
+    return static_cast<WQuickTextInputV3::ContentPurpose>(d->handle->content_type.purpose);
+}
+
+QRect WTextInputV3State::cursorRect() const
+{
+    W_DC(WTextInputV3State);
+    return WTools::fromWLRBox(&d->handle->cursor_rectangle);
+}
+
+WTextInputV3State::Features WTextInputV3State::features() const
+{
+    W_DC(WTextInputV3State);
+    return Features(d->handle->features);
+}
+
+WTextInputV3State::WTextInputV3State(wlr_text_input_v3_state *handle, QObject *parent)
+    : QObject(parent)
+    , WObject(*new WTextInputV3StatePrivate(handle, this))
+{ }
+
+QDebug operator<<(QDebug debug, const WTextInputV3State &state)
+{
+    debug << "SurroundingText: " << state.surroundingText() << Qt::endl;
+    debug << "SurroundingCursor: " << state.surroundingCursor() << Qt::endl;
+    debug << "SurroundingAnchor: " << state.surroundingAnchor() << Qt::endl;
+    debug << "CursorRect: " << state.cursorRect() << Qt::endl;
+    debug << "ContentHint: " << state.contentHint() << Qt::endl;
+    debug << "ContentPurpose: " << state.contentPurpose() << Qt::endl;
+    debug << "Features: " << state.features();
+    return debug;
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquicktextinputv3_p.h
+++ b/src/server/qtquick/private/wquicktextinputv3_p.h
@@ -1,0 +1,171 @@
+// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <wglobal.h>
+#include <wquickwaylandserver.h>
+
+#include <qwglobal.h>
+
+#include <QQmlEngine>
+#include <QRect>
+
+Q_MOC_INCLUDE("wsurfaceitem.h")
+Q_MOC_INCLUDE("wtoplevelsurface.h")
+Q_MOC_INCLUDE("wsurface.h")
+Q_MOC_INCLUDE("wseat.h")
+Q_MOC_INCLUDE(<qwtextinputv3.h>)
+
+QW_BEGIN_NAMESPACE
+class QWTextInputV3;
+class QWTextInputManagerV3;
+QW_END_NAMESPACE
+
+struct wlr_text_input_v3_state;
+WAYLIB_SERVER_BEGIN_NAMESPACE
+class WQuickTextInputV3Private;
+class WToplevelSurface;
+class WSurfaceItem;
+class WSurface;
+class WQuickTextInputV3;
+class WQuickTextInputManagerV3Private;
+class WSeat;
+class WTextInputV3State;
+
+class WAYLIB_SERVER_EXPORT WQuickTextInputManagerV3 : public WQuickWaylandServerInterface, public WObject
+{
+    Q_OBJECT
+    W_DECLARE_PRIVATE(WQuickTextInputManagerV3)
+    QML_NAMED_ELEMENT(TextInputManagerV3)
+    Q_PROPERTY(QList<WQuickTextInputV3 *> textInputs READ textInputs)
+
+public:
+    explicit WQuickTextInputManagerV3(QObject *parent = nullptr);
+    QList<WQuickTextInputV3 *> textInputs() const;
+
+Q_SIGNALS:
+    void newTextInput(WQuickTextInputV3 *ti);
+
+private:
+    void create() override;
+};
+
+class WQuickTextInputV3 : public QObject, public WObject
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(TextInputV3)
+    QML_UNCREATABLE("Only created by TextInputManagerV3 in C++")
+    W_DECLARE_PRIVATE(WQuickTextInputV3)
+
+    Q_PROPERTY(WSeat *seat READ seat CONSTANT FINAL)
+    Q_PROPERTY(WTextInputV3State *state READ state CONSTANT FINAL)
+    Q_PROPERTY(WTextInputV3State *pendingState READ pendingState CONSTANT FINAL)
+    Q_PROPERTY(WSurface *focusedSurface READ focusedSurface FINAL)
+
+public:
+    enum ChangeCause {
+        InputMethod,
+        Other
+    };
+    Q_ENUM(ChangeCause)
+
+    enum ContentHint {
+        None = 0x0,
+        Completion = 0x1,
+        Spellcheck = 0x2,
+        AutoCapitalization = 0x4,
+        Lowercase = 0x8,
+        Uppercase = 0x10,
+        Titlecase = 0x20,
+        HiddenText = 0x40,
+        SensitiveData = 0x80,
+        Latin = 0x100,
+        Multiline = 0x200
+    };
+    Q_ENUM(ContentHint)
+
+    enum ContentPurpose {
+        Normal,
+        Alpha,
+        Digits,
+        Number,
+        Phone,
+        Url,
+        Email,
+        Name,
+        Password,
+        Pin,
+        Date,
+        Time,
+        Datetime,
+        Terminal
+    };
+    Q_ENUM(ContentPurpose)
+
+    WSeat *seat() const;
+    WTextInputV3State *state() const;
+    WTextInputV3State *pendingState() const;
+    WSurface *focusedSurface() const;
+    wl_client *waylandClient() const;
+    QW_NAMESPACE::QWTextInputV3 *handle() const;
+
+public Q_SLOTS:
+    void sendEnter(WSurface *surface);
+    void sendLeave();
+    void sendPreeditString(const QString &text, qint32 cursorBegin, qint32 cursorEnd);
+    void sendCommitString(const QString &text);
+    void sendDeleteSurroundingText(quint32 beforeLength, quint32 afterLength);
+    void sendDone();
+
+Q_SIGNALS:
+    void enable();
+    void disable();
+    void commit();
+
+private:
+    WQuickTextInputV3(QW_NAMESPACE::QWTextInputV3 *handle, QObject *parent);
+    friend class WQuickTextInputManagerV3;
+};
+
+class WTextInputV3StatePrivate;
+class WTextInputV3State : public QObject, public WObject
+{
+    Q_OBJECT
+    W_DECLARE_PRIVATE(WTextInputV3State)
+    Q_PROPERTY(QString surroundingText READ surroundingText FINAL)
+    Q_PROPERTY(quint32 surroundingCursor READ surroundingCursor FINAL)
+    Q_PROPERTY(quint32 surroundingAnchor READ surroundingAnchor FINAL)
+    Q_PROPERTY(WQuickTextInputV3::ChangeCause textChangeCause READ textChangeCause FINAL)
+    Q_PROPERTY(WQuickTextInputV3::ContentHint contentHint READ contentHint FINAL)
+    Q_PROPERTY(WQuickTextInputV3::ContentPurpose contentPurpose READ contentPurpose FINAL)
+    Q_PROPERTY(QRect cursorRect READ cursorRect FINAL)
+    Q_PROPERTY(Features features READ features FINAL)
+
+public:
+    enum Feature {
+        SurroundingText = 1 << 0,
+        ContentType = 1 << 1,
+        CursorRect = 1 << 2
+    };
+    Q_FLAG(Feature)
+    Q_DECLARE_FLAGS(Features, Feature)
+
+    wlr_text_input_v3_state *handle() const;
+    QString surroundingText() const;
+    quint32 surroundingCursor() const;
+    quint32 surroundingAnchor() const;
+    WQuickTextInputV3::ChangeCause textChangeCause() const;
+    WQuickTextInputV3::ContentHint contentHint() const;
+    WQuickTextInputV3::ContentPurpose contentPurpose() const;
+    QRect cursorRect() const;
+    Features features() const;
+
+    friend QDebug operator<<(QDebug debug, const WTextInputV3State &state);
+
+private:
+    explicit WTextInputV3State(wlr_text_input_v3_state *handle, QObject *parent = nullptr);
+    friend class WQuickTextInputV3Private;
+};
+WAYLIB_SERVER_END_NAMESPACE
+Q_DECLARE_METATYPE(WAYLIB_SERVER_NAMESPACE::WTextInputV3State::Features)

--- a/src/server/qtquick/private/wquickvirtualkeyboardv1.cpp
+++ b/src/server/qtquick/private/wquickvirtualkeyboardv1.cpp
@@ -1,0 +1,89 @@
+// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wquickvirtualkeyboardv1_p.h"
+#include "winputdevice.h"
+
+#include <qwvirtualkeyboardv1.h>
+
+#include <QLoggingCategory>
+
+extern "C" {
+#include <wlr/types/wlr_virtual_keyboard_v1.h>
+}
+
+QW_USE_NAMESPACE
+WAYLIB_SERVER_BEGIN_NAMESPACE
+Q_DECLARE_LOGGING_CATEGORY(qLcInputMethod)
+class WQuickVirtualKeyboardV1Private : public WObjectPrivate
+{
+    W_DECLARE_PUBLIC(WQuickVirtualKeyboardV1)
+public:
+    WQuickVirtualKeyboardV1Private(QWVirtualKeyboardV1 *h, WQuickVirtualKeyboardV1 *qq)
+        : WObjectPrivate(qq)
+        , handle(h)
+        , keyboard(new WInputDevice(QWInputDevice::from(&h->handle()->keyboard.base)))
+    { }
+
+    QWVirtualKeyboardV1 *const handle;
+    WInputDevice *const keyboard;
+};
+
+class WQuickVirtualKeyboardManagerV1Private : public WObjectPrivate
+{
+    W_DECLARE_PUBLIC(WQuickVirtualKeyboardManagerV1)
+public:
+    explicit WQuickVirtualKeyboardManagerV1Private(WQuickVirtualKeyboardManagerV1 *qq)
+        : WObjectPrivate(qq)
+        , manager(nullptr)
+    { }
+
+    QWVirtualKeyboardManagerV1 *manager;
+    QList<WQuickVirtualKeyboardV1 *> virtualKeyboards;
+};
+
+WQuickVirtualKeyboardManagerV1::WQuickVirtualKeyboardManagerV1(QObject *parent)
+    : WQuickWaylandServerInterface(parent)
+    , WObject(*new WQuickVirtualKeyboardManagerV1Private(this))
+{}
+
+QList<WQuickVirtualKeyboardV1 *> WQuickVirtualKeyboardManagerV1::virtualKeyboards() const
+{
+    W_DC(WQuickVirtualKeyboardManagerV1);
+    return d->virtualKeyboards;
+}
+
+void WQuickVirtualKeyboardManagerV1::create()
+{
+    W_D(WQuickVirtualKeyboardManagerV1);
+    WQuickWaylandServerInterface::create();
+    d->manager = QWVirtualKeyboardManagerV1::create(server()->handle());
+    connect(d->manager, &QWVirtualKeyboardManagerV1::newVirtualKeyboard, this, [this, d](QWVirtualKeyboardV1 *vk) {
+        auto quickVirtualKeyboard = new WQuickVirtualKeyboardV1(vk, this);
+        d->virtualKeyboards.append(quickVirtualKeyboard);
+        connect(quickVirtualKeyboard->handle(), &QWVirtualKeyboardV1::beforeDestroy, this, [this, d, quickVirtualKeyboard]() {
+            d->virtualKeyboards.removeAll(quickVirtualKeyboard);
+            quickVirtualKeyboard->deleteLater();
+        });
+        Q_EMIT this->newVirtualKeyboard(quickVirtualKeyboard);
+    });
+}
+
+QWVirtualKeyboardV1 *WQuickVirtualKeyboardV1::handle() const
+{
+    W_DC(WQuickVirtualKeyboardV1);
+    return d->handle;
+}
+
+WInputDevice *WQuickVirtualKeyboardV1::keyboard() const
+{
+    W_DC(WQuickVirtualKeyboardV1);
+    return d->keyboard;
+}
+
+WQuickVirtualKeyboardV1::WQuickVirtualKeyboardV1(QWVirtualKeyboardV1 *handle, QObject *parent)
+    : QObject(parent)
+    , WObject(*new WQuickVirtualKeyboardV1Private(handle, this))
+{ }
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquickvirtualkeyboardv1_p.h
+++ b/src/server/qtquick/private/wquickvirtualkeyboardv1_p.h
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <wglobal.h>
+#include <wquickwaylandserver.h>
+
+#include <qwglobal.h>
+#include <qwkeyboard.h>
+
+Q_MOC_INCLUDE("winputdevice.h")
+
+QW_BEGIN_NAMESPACE
+class QWVirtualKeyboardV1;
+class QWKeyboard;
+QW_END_NAMESPACE
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+class WQuickVirtualKeyboardV1Private;
+class WQuickVirtualKeyboardManagerV1Private;
+class WInputDevice;
+
+class WQuickVirtualKeyboardV1 : public QObject, public WObject
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(VirtualKeyboardV1)
+    QML_UNCREATABLE("Only created by VirtualKeyboardManagerV1 in C++")
+    W_DECLARE_PRIVATE(WQuickVirtualKeyboardV1)
+    Q_PROPERTY(WInputDevice* keyboard READ keyboard CONSTANT FINAL)
+
+public:
+    QW_NAMESPACE::QWVirtualKeyboardV1 *handle() const;
+    WInputDevice *keyboard() const;
+
+private:
+    explicit WQuickVirtualKeyboardV1(QW_NAMESPACE::QWVirtualKeyboardV1 *handle, QObject *parent = nullptr);
+    friend class WQuickVirtualKeyboardManagerV1;
+};
+
+class WQuickVirtualKeyboardManagerV1 : public WQuickWaylandServerInterface, public WObject
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(VirtualKeyboardManagerV1)
+    W_DECLARE_PRIVATE(WQuickVirtualKeyboardManagerV1)
+    Q_PROPERTY(QList<WQuickVirtualKeyboardV1 *> virtualKeyboards READ virtualKeyboards FINAL)
+
+public:
+    explicit WQuickVirtualKeyboardManagerV1(QObject *parent = nullptr);
+    QList<WQuickVirtualKeyboardV1 *> virtualKeyboards() const;
+
+Q_SIGNALS:
+    void newVirtualKeyboard(WQuickVirtualKeyboardV1 *vk);
+
+private:
+    void create() override;
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/wquicktextureproxy.cpp
+++ b/src/server/qtquick/wquicktextureproxy.cpp
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
 //
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wquicktextureproxy.h"
 #include "wquicktextureproxy_p.h"


### PR DESCRIPTION
* Implement text-input-unstable-v3.
* Implement input-method-unstable-v2.
* Implement virtual-keyboard-unstable-v1.
* Refactor WToplevelSurface, add property parentSurface, and correct the implementation of parentXdgSurface() in WXdgSurface.
* Add keyboard property and nativeHandle() for WSeat.
* Fix one runtime warning, and add an option to disable the demo client.