### PR TITLE
fix: text input v3 enabled event being ignored

### DIFF
--- a/src/server/qtquick/private/winputmethodhelper.cpp
+++ b/src/server/qtquick/private/winputmethodhelper.cpp
@@ -228,8 +228,10 @@ void WInputMethodHelper::onNewVirtualKeyboardV1(WQuickVirtualKeyboardV1 *newVirt
 
 void WInputMethodHelper::onTextInputV3Enabled(WQuickTextInputV3 *enabledTextInputV3)
 {
-    if (activeTextInputV3())
-        return;
+    if (activeTextInputV3()) {
+        // Assume that previous active text input has been disabled
+        onTextInputV3Disabled(activeTextInputV3());
+    }
     setActiveTextInputV3(enabledTextInputV3);
     auto im = inputMethodV2();
     if (im) {
@@ -241,12 +243,13 @@ void WInputMethodHelper::onTextInputV3Enabled(WQuickTextInputV3 *enabledTextInpu
 void WInputMethodHelper::onTextInputV3Disabled(WQuickTextInputV3 *disabledTextInputV3)
 {
     if (activeTextInputV3() == disabledTextInputV3) {
+        // Should we consider the case when the same text input is disabled and then enabled at the same time.
         setActiveTextInputV3(nullptr);
-    }
-    auto im = inputMethodV2();
-    if (im) {
-        im->sendDeactivate();
-        sendInputMethodV2State(disabledTextInputV3);
+        auto im = inputMethodV2();
+        if (im) {
+            im->sendDeactivate();
+            sendInputMethodV2State(disabledTextInputV3);
+        }
     }
 }
 


### PR DESCRIPTION
WInputMethodHelper will ignore enabled event of text input v3 when active text input v3 is not disabled yet. This might cause event loss when there are multiple text inputs and the older's disabled event is handled after the newer's enabled event. Just assume the current active text input v3 has been disabled in compositor side. And add check in disabled handler to prevent double deactivate.

Log: fix text input v3 enabled event being ignored