### PR TITLE
chore: remove unused properties

### DIFF
--- a/examples/tinywl/helper.h
+++ b/examples/tinywl/helper.h
@@ -25,10 +25,6 @@ class Helper : public WSeatEventFilter {
     Q_PROPERTY(WToplevelSurface* activatedSurface READ activatedSurface WRITE setActivateSurface NOTIFY activatedSurfaceChanged FINAL)
     Q_PROPERTY(WSurfaceItem* resizingItem READ resizingItem NOTIFY resizingItemChanged FINAL)
     Q_PROPERTY(WSurfaceItem* movingItem READ movingItem NOTIFY movingItemChanged)
-    Q_PROPERTY(quint32 topExclusiveMargin NOTIFY topExclusiveMarginChanged)
-    Q_PROPERTY(quint32 bottomExclusiveMargin NOTIFY bottomExclusiveMarginChanged)
-    Q_PROPERTY(quint32 leftExclusiveMargin NOTIFY leftExclusiveMarginChanged)
-    Q_PROPERTY(quint32 rightExclusiveMargin NOTIFY rightExclusiveMarginChanged)
     QML_ELEMENT
     QML_SINGLETON
 


### PR DESCRIPTION
These properties in helper.h does not have a read function thus cannot be accessed in qml. We only need its changed signal. Remove these Q_PROPERTY declarations.

Log: remove unused properties