### PR TITLE
Fix crash when re-enter origin pointer focus

### DIFF
--- a/src/server/kernel/wseat.cpp
+++ b/src/server/kernel/wseat.cpp
@@ -172,7 +172,9 @@ public:
         }
         Q_ASSERT(pointerFocusSurface() == surface->handle()->handle());
 
-        Q_ASSERT(!pointerFocusEventObject || eventObject != pointerFocusEventObject);
+        if (pointerFocusEventObject && eventObject == pointerFocusEventObject)
+            return true;
+
         if (pointerFocusEventObject) {
             Q_ASSERT(onEventObjectDestroy);
             QObject::disconnect(onEventObjectDestroy);


### PR DESCRIPTION
When leaving the surface while the focus is grabbed by a scroll bar. then returning to the surface again, `eventObject == pointerFocusEventObject` is possible
