### PR TITLE
fix: input popup surface item not removed

### DIFF
--- a/examples/tinywl/Main.qml
+++ b/examples/tinywl/Main.qml
@@ -203,7 +203,7 @@ Item {
         }
         onInputPopupSurfaceV2Removed: function (surface) {
             QmlHelper.inputPopupSurfaceManager.removeIf(function (prop) {
-                return prop.waylandSurface === surface
+                return prop.popupSurface === surface
             })
         }
     }


### PR DESCRIPTION
Fix input popup surface item not removed due to wrong property name.

Log: fix input popup surface item not removed