### PR TITLE
Fix position of popup component

### DIFF
--- a/examples/tinywl/XdgSurface.qml
+++ b/examples/tinywl/XdgSurface.qml
@@ -18,7 +18,7 @@ XdgSurfaceItem {
         onEnterOutput: function(output) {
             waylandSurface.surface.enterOutput(output)
             Helper.onSurfaceEnterOutput(waylandSurface, surfaceItem, output)
-            if (!surfaceItem.isPopup) {
+            if (!waylandSurface.isPopup) {
                 // don't change initial position of popup
                 surfaceItem.x = Helper.getLeftExclusiveMargin(waylandSurface) + 10
                 surfaceItem.y = Helper.getTopExclusiveMargin(waylandSurface) + 10


### PR DESCRIPTION
1. check isPopup should use WaylandXdgSurface, not XdgSurfaceItem
2. parent of popup should be parentItem.item, shell(Popup type) is not QQuickItem
3. check popup position do not exceed the screen display area