### PR TITLE
fix: owner conflict when reusing wlr_surface

### DIFF
--- a/src/server/qtquick/private/wquickinputmethodv2.cpp
+++ b/src/server/qtquick/private/wquickinputmethodv2.cpp
@@ -69,8 +69,13 @@ public:
     WQuickInputPopupSurfaceV2Private(QWInputPopupSurfaceV2 *h, WQuickInputPopupSurfaceV2 *qq)
         : WObjectPrivate(qq)
         , handle(h)
-        , popupSurface(new WSurface(h->surface(), qq))
-    { }
+        , popupSurface(WSurface::fromHandle(h->surface()))
+    {
+        if (!popupSurface) {
+            popupSurface = new WSurface(h->surface());
+            QObject::connect(h->surface(), &QWSurface::beforeDestroy, popupSurface, &WSurface::deleteLater);
+        }
+    }
 
     W_DECLARE_PUBLIC(WQuickInputPopupSurfaceV2)
     QWInputPopupSurfaceV2 *handle;


### PR DESCRIPTION
InputMethodPopupSurfaceV2's surface might be reused. As previous surface not destroyed, creating a new WSurface from it might cause an owner conflict. Try to find an existent one first.

Log: fix owner conflict when reusing wlr_surface