### PR TITLE
Fix hardware cursor can't move if content is not repaint

### DIFF
--- a/examples/tinywl/Main.qml
+++ b/examples/tinywl/Main.qml
@@ -17,7 +17,8 @@ Item {
             id: backend
 
             onOutputAdded: function(output) {
-                output.forceSoftwareCursor = true // Test
+                if (!backend.hasDrm)
+                    output.forceSoftwareCursor = true // Test
 
                 Helper.allowNonDrmOutputAutoChangeMode(output)
                 QmlHelper.outputManager.add({waylandOutput: output})

--- a/src/server/qtquick/private/wquickbackend.cpp
+++ b/src/server/qtquick/private/wquickbackend.cpp
@@ -75,6 +75,40 @@ QWBackend *WQuickBackend::backend() const
     return d->backend->nativeInterface<QWBackend>();
 }
 
+template<class T>
+static bool hasBackend(QWBackend *handle)
+{
+    if (qobject_cast<T*>(handle))
+        return true;
+    if (auto multiBackend = qobject_cast<QWMultiBackend*>(handle)) {
+        bool exists = false;
+        multiBackend->forEachBackend([] (wlr_backend *backend, void *userData) {
+            bool &exists = *reinterpret_cast<bool*>(userData);
+            if (T::from(backend))
+                exists = true;
+        }, &exists);
+
+        return exists;
+    }
+
+    return false;
+}
+
+bool WQuickBackend::hasDrm() const
+{
+    return hasBackend<QWDrmBackend>(backend());
+}
+
+bool WQuickBackend::hasX11() const
+{
+    return hasBackend<QWX11Backend>(backend());
+}
+
+bool WQuickBackend::hasWayland() const
+{
+    return hasBackend<QWWaylandBackend>(backend());
+}
+
 void WQuickBackend::create()
 {
     WQuickWaylandServerInterface::create();

--- a/src/server/qtquick/private/wquickbackend_p.h
+++ b/src/server/qtquick/private/wquickbackend_p.h
@@ -28,12 +28,18 @@ class WAYLIB_SERVER_EXPORT WQuickBackend : public WQuickWaylandServerInterface, 
     Q_OBJECT
     W_DECLARE_PRIVATE(WQuickBackend)
     Q_PROPERTY(WSocket* ownsSocket READ ownsSocket CONSTANT)
+    Q_PROPERTY(bool hasDrm READ hasDrm FINAL)
+    Q_PROPERTY(bool hasX11 READ hasDrm FINAL)
+    Q_PROPERTY(bool hasWayland READ hasDrm FINAL)
     QML_NAMED_ELEMENT(WaylandBackend)
 
 public:
     explicit WQuickBackend(QObject *parent = nullptr);
 
     QW_NAMESPACE::QWBackend *backend() const;
+    bool hasDrm() const;
+    bool hasX11() const;
+    bool hasWayland() const;
 
 Q_SIGNALS:
     void outputAdded(WOutput *output);


### PR DESCRIPTION
tinywl: Enable hardware cursor on DRM backend.