### PR TITLE
Disable preserveColorContents on default

### DIFF
--- a/examples/tinywl/OutputDelegate.qml
+++ b/examples/tinywl/OutputDelegate.qml
@@ -49,7 +49,6 @@ OutputItem {
         output: waylandOutput
         devicePixelRatio: parent.devicePixelRatio
         anchors.centerIn: parent
-        preserveColorContents: !rotationAnimator.running
 
         RotationAnimation {
             id: rotationAnimator
@@ -109,7 +108,6 @@ OutputItem {
             output: waylandOutput
             devicePixelRatio: outputViewport.devicePixelRatio
             layerFlags: OutputViewport.AlwaysAccepted
-            preserveColorContents: !rotationAnimator.running
 
             TextureProxy {
                 sourceItem: outputViewport

--- a/src/server/qtquick/private/woutputviewport_p.h
+++ b/src/server/qtquick/private/woutputviewport_p.h
@@ -30,7 +30,7 @@ public:
     WOutputViewportPrivate()
         : offscreen(false)
         , root(false)
-        , preserveColorContents(true)
+        , preserveColorContents(false)
     {
 
     }


### PR DESCRIPTION
Because this is a performance hazard for some GPU architectures (like tiled mobile GPus due to having to reload data onto the on-chip buffer.