### PR TITLE
tinywl: Fix magnifying glass on multi outputs

### DIFF
--- a/examples/tinywl/OutputDelegate.qml
+++ b/examples/tinywl/OutputDelegate.qml
@@ -104,6 +104,7 @@ OutputItem {
         OutputViewport {
             readonly property OutputItem outputItem: waylandOutput.OutputItem.item
 
+            id: viewport
             root: true
             output: waylandOutput
             devicePixelRatio: outputViewport.devicePixelRatio
@@ -111,6 +112,7 @@ OutputItem {
 
             TextureProxy {
                 sourceItem: outputViewport
+                anchors.fill: parent
             }
 
             Item {
@@ -140,6 +142,8 @@ OutputItem {
                             smooth: false
                             scale: 10
                             transformOrigin: Item.TopLeft
+                            width: viewport.width
+                            height: viewport.height
 
                             function updatePosition() {
                                 const pos = outputItem.lastActiveCursorItem.mapToItem(outputViewport, Qt.point(0, 0))


### PR DESCRIPTION
When there are multiple screens, and the scaling factor of the second screen is greater than that of the first screen, if the magnifying glass is activated on the first screen, the automatically calculated size by TextureProxy is incorrect. This leads to an incorrect display area for the proxied OutputViewport.