### PR TITLE
Fix WSurfaceItem setFocus

### DIFF
--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -163,11 +163,7 @@ private:
                 return true;
             break;
         }
-        case FocusOut: {
-            if (isValid())
-                d()->q_func()->setFocus(false);
-            break;
-        }
+        // No need to process focusOut, see [PR 282](https://github.com/vioken/waylib/pull/282)
         default:
             break;
         }

--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -1216,7 +1216,7 @@ void WSurfaceItemPrivate::updateEventItem(bool forceDestroy)
         eventItem->setVisible(false);
         eventItem->setParentItem(nullptr);
         eventItem->setParent(nullptr);
-        delete eventItem;
+        eventItem->deleteLater();
         eventItem = nullptr;
     } else {
         eventItem = new EventItem(q_func());


### PR DESCRIPTION
change focus prop on focusout event will disturb its binding in qml, so disabled.
When disabled, activefocus update may not function before next eventloop, so crash in `doRender -> polishItem`. change to `eventItem->deleteLater` to resolve.