### PR TITLE
Wlr_swapchain will destroy follow alloc so stop use unique_ptr

### DIFF
--- a/src/server/qtquick/wrenderhelper.cpp
+++ b/src/server/qtquick/wrenderhelper.cpp
@@ -654,20 +654,13 @@ QSGRendererInterface::GraphicsApi WRenderHelper::probe(QWBackend *testBackend, c
                 , allocDeleter
             };
 
-            auto swapchainDeleter = [](wlr_swapchain *swapchain) {
-                wlr_swapchain_destroy(swapchain);
-            };
-
             bool hasSupportedFormat = false;
             for (int formatId = 0; formatId < formats->len; formatId++) {
                 auto *format = &formats->formats[formatId];
 
-                std::unique_ptr<wlr_swapchain, decltype(swapchainDeleter)> swapchain {
-                    wlr_swapchain_create(alloc.get(), 1000, 800, format)
-                    , swapchainDeleter
-                };
+                auto *swapchain = wlr_swapchain_create(alloc.get(), 1000, 800, format); // destroy follow alloc
 
-                auto *buffer = wlr_swapchain_acquire(swapchain.get(), nullptr); // destroy follow swapchain
+                auto *buffer = wlr_swapchain_acquire(swapchain, nullptr); // destroy follow swapchain
 
                 if (!buffer) {
                     continue;


### PR DESCRIPTION
```
struct wlr_swapchain *wlr_swapchain_create(
		struct wlr_allocator *alloc, int width, int height,
		const struct wlr_drm_format *format) {
	struct wlr_swapchain *swapchain = calloc(1, sizeof(*swapchain));
	if (swapchain == NULL) {
		return NULL;
	}
	swapchain->allocator = alloc;
	swapchain->width = width;
	swapchain->height = height;

	if (!wlr_drm_format_copy(&swapchain->format, format)) {
		free(swapchain);
		return NULL;
	}

	swapchain->allocator_destroy.notify = swapchain_handle_allocator_destroy;
	wl_signal_add(&alloc->events.destroy, &swapchain->allocator_destroy);

	return swapchain;
}
```