### PR TITLE
Fix: convert assigned qjsvalue to QVariantMap

### DIFF
--- a/src/server/qtquick/private/wqmldynamiccreator.cpp
+++ b/src/server/qtquick/private/wqmldynamiccreator.cpp
@@ -306,8 +306,11 @@ QVariant WQmlCreatorComponent::chooserRoleValue() const
     return m_chooserRoleValue;
 }
 
-void WQmlCreatorComponent::setChooserRoleValue(const QVariant &newChooserRoleValue)
+void WQmlCreatorComponent::setChooserRoleValue(QVariant newChooserRoleValue)
 {
+    // jsvalue assigned to qproperty aren't auto converted to QVariantMap, differs with invoke args
+    if (newChooserRoleValue.canConvert<QJSValue>())
+        newChooserRoleValue = newChooserRoleValue.value<QJSValue>().toVariant();
     if (m_chooserRoleValue == newChooserRoleValue)
         return;
     m_chooserRoleValue = newChooserRoleValue;

--- a/src/server/qtquick/private/wqmldynamiccreator_p.h
+++ b/src/server/qtquick/private/wqmldynamiccreator_p.h
@@ -91,7 +91,7 @@ public:
     void setChooserRole(const QString &newChooserRole);
 
     QVariant chooserRoleValue() const;
-    void setChooserRoleValue(const QVariant &newChooserRoleValue);
+    void setChooserRoleValue(QVariant newChooserRoleValue);
 
     bool autoDestroy() const;
     void setAutoDestroy(bool newAutoDestroy);


### PR DESCRIPTION
Convert QProperty's assigned QVariant<QJSvalue> to QVariantMap, to keep persist with method invoke args.
DynamicCreator's choosorRoleValue can be a js object, dict etc. 