### PR TITLE
fix: archlinux-build-wlroots-17 CI failed on missing debugedit

### DIFF
--- a/.github/workflows/archlinux-build-wlroots-17.yaml
+++ b/.github/workflows/archlinux-build-wlroots-17.yaml
@@ -21,7 +21,7 @@ jobs:
           pacman --noconfirm --noprogressbar -Syu
       - name: Install dep
         run: |
-          pacman -Syu --noconfirm --noprogressbar qt6-base qt6-declarative cmake pkgconfig pixman wlroots wayland-protocols git
+          pacman -Syu --noconfirm --noprogressbar base-devel qt6-base qt6-declarative cmake pkgconfig pixman wlroots wayland-protocols git
           pacman -Syu --noconfirm --noprogressbar clang ninja make
           pacman -Syu --noconfirm --noprogressbar fakeroot meson sudo
       - name: Set up user


### PR DESCRIPTION
Add missing base-devel dep
see https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/issues/18