### PR TITLE
Feat: expose output specified on creation to qml

### DIFF
--- a/src/server/kernel/wlayersurface.cpp
+++ b/src/server/kernel/wlayersurface.cpp
@@ -6,10 +6,12 @@
 #include "wseat.h"
 #include "wtools.h"
 #include "wsurface.h"
+#include "woutput.h"
 
 #include <qwlayershellv1.h>
 #include <qwseat.h>
 #include <qwcompositor.h>
+#include <qwoutput.h>
 
 #include <QDebug>
 
@@ -70,6 +72,7 @@ public:
     int32_t topMargin = 0, bottomMargin = 0;
     int32_t exclusiveZone = 0;
     WLayerSurface::KeyboardInteractivity keyboardInteractivity = WLayerSurface::KeyboardInteractivity::None;
+    WOutput *output = nullptr;
 };
 
 WLayerSurfacePrivate::WLayerSurfacePrivate(WLayerSurface *qq, QWLayerSurfaceV1 *hh)
@@ -96,6 +99,7 @@ void WLayerSurfacePrivate::init()
     surface = new WSurface(handle->surface(), q);
     surface->setAttachedData<WLayerSurface>(q);
     updateLayerProperty();
+    output = nativeHandle()->output ? WOutput::fromHandle(QWOutput::from(nativeHandle()->output)) : nullptr;
 
     connect();
 }
@@ -360,6 +364,12 @@ WLayerSurface::KeyboardInteractivity WLayerSurface::keyboardInteractivity() cons
 {
     W_DC(WLayerSurface);
     return d->keyboardInteractivity;
+}
+
+WOutput *WLayerSurface::output() const
+{
+    W_DC(WLayerSurface);
+    return d->output;
 }
 
 WLayerSurface::AnchorType WLayerSurface::getExclusiveZoneEdge() const

--- a/src/server/kernel/wlayersurface.h
+++ b/src/server/kernel/wlayersurface.h
@@ -5,6 +5,7 @@
 
 #include <WSurface>
 #include <wtoplevelsurface.h>
+#include <WOutput>
 
 struct wlr_layer_surface_v1;
 
@@ -32,6 +33,7 @@ class WAYLIB_SERVER_EXPORT WLayerSurface : public WToplevelSurface, public WObje
     Q_PROPERTY(int32_t topMargin READ topMargin NOTIFY topMarginChanged)
     Q_PROPERTY(int32_t bottomMargin READ bottomMargin NOTIFY bottomMarginChanged)
     Q_PROPERTY(KeyboardInteractivity keyboardInteractivity READ keyboardInteractivity NOTIFY keyboardInteractivityChanged)
+    Q_PROPERTY(WOutput *output READ output CONSTANT) // constant in wlr_layershell_v1
 
     QML_NAMED_ELEMENT(WaylandLayerSurface)
     QML_UNCREATABLE("Only create in C++")
@@ -92,6 +94,7 @@ public:
     int32_t topMargin() const;
     int32_t bottomMargin() const;
     KeyboardInteractivity keyboardInteractivity() const;
+    WOutput *output() const;
     Q_INVOKABLE AnchorType getExclusiveZoneEdge() const;
     Q_INVOKABLE uint32_t configureSize(const QSize &newSize);
 


### PR DESCRIPTION
Only configured on creation, so use CONSTANT qproperty
see https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_shell_v1:request:get_layer_surface