### PR TITLE
Fix: frame done optimization should consider shaderEffectSource etc.

### DIFF
--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -16,6 +16,7 @@
 
 #include <QQuickWindow>
 #include <QSGImageNode>
+#include <QSGRenderNode>
 #include <private/qquickitem_p.h>
 
 extern "C" {
@@ -233,8 +234,6 @@ public:
             updateSurfaceState();
         });
         QObject::connect(surface, &WSurface::primaryOutputChanged, q, [this] {
-            updateFrameDoneConnection();
-
             if (textureProvider)
                 textureProvider->maybeUpdateTextureOnSurfacePrrimaryOutputChanged();
         });
@@ -256,14 +255,13 @@ public:
         if (frameDoneConnection)
             QObject::disconnect(frameDoneConnection);
 
-        if (auto output = surface->primaryOutput()) {
-            frameDoneConnection = QObject::connect(output, &WOutput::bufferCommitted,[&](){
-                if (auto privt=QQuickItemPrivate::get(q_func()); ( q_func()->isVisible()
-                    || (privt->extra.isAllocated() && privt->extra->recursiveEffectRefCount ) )) {
-                        Q_EMIT surface->notifyFrameDone();
-                }
-            });
-        }
+        // wayland protocol job should not run in rendering thread, so set context qobject to contentItem
+        frameDoneConnection = QObject::connect(q_func()->window(), &QQuickWindow::afterRendering, q_func(), [this](){
+            if (q_func()->rendered) {
+                surface->notifyFrameDone();
+                q_func()->rendered = false;
+            }
+        }); // if signal is emitted from seperated rendering thread, default QueuedConnection is used
     }
 
     void updateSurfaceState() {
@@ -367,8 +365,30 @@ void WSurfaceItemContent::componentComplete()
         d->init();
 }
 
+class WSGRenderFootprintNode: public QSGRenderNode
+{
+public:
+    WSGRenderFootprintNode(WSurfaceItemContent *owner)
+        : QSGRenderNode()
+        , m_owner(owner)
+    {
+        setFlag(QSGNode::OwnedByParent); // parent is fixed, auto release
+    }
+
+    ~WSGRenderFootprintNode() {}
+
+    void render(const RenderState*) override
+    {
+        if (Q_LIKELY(m_owner))
+            m_owner->rendered = true;
+    }
+
+    QPointer<WSurfaceItemContent> m_owner;
+};
+
 QSGNode *WSurfaceItemContent::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
 {
+    auto privt = QQuickItemPrivate::get(this);
     W_D(WSurfaceItemContent);
     if (!d->textureProvider || !d->textureProvider->texture() || width() <= 0 || height() <= 0) {
         delete oldNode;
@@ -381,6 +401,8 @@ QSGNode *WSurfaceItemContent::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeD
         node = window()->createImageNode();
         node->setOwnsTexture(false);
         node->setTexture(texture);
+        QSGNode *fpnode = new WSGRenderFootprintNode(this);
+        node->appendChildNode(fpnode);
     } else {
         node->markDirty(QSGNode::DirtyMaterial);
     }
@@ -426,10 +448,6 @@ void WSurfaceItemContent::itemChange(ItemChange change, const ItemChangeData &da
 {
     QQuickItem::itemChange(change, data);
     W_D(WSurfaceItemContent);
-
-    if (change == ItemVisibleHasChanged) {
-        // lazy frameDone connection no more processed here
-    }
 }
 
 void WSurfaceItemContent::invalidateSceneGraph()

--- a/src/server/qtquick/wsurfaceitem.h
+++ b/src/server/qtquick/wsurfaceitem.h
@@ -43,11 +43,13 @@ private:
     friend class WSurfaceItem;
     friend class WSurfaceItemPrivate;
     friend class WSGTextureProvider;
+    friend class WSGRenderFootprintNode;
 
     void componentComplete() override;
     QSGNode *updatePaintNode(QSGNode *, UpdatePaintNodeData *) override;
     void releaseResources() override;
     void itemChange(ItemChange change, const ItemChangeData &data) override;
+    QAtomicInteger<bool> rendered = false;
 
     // Using by Qt library
     Q_SLOT void invalidateSceneGraph();


### PR DESCRIPTION
item's visible is not enough, should consider itemprivate's ref count.
must use recursiveEffectItemRefcount which refs the whole child item tree.
can't be driven merely by itemChange, check on every output commit