### PR TITLE
Fix: trigger resize when resize mode changed

### DIFF
--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -610,6 +610,8 @@ void WSurfaceItem::setResizeMode(ResizeMode newResizeMode)
     if (d->resizeMode == newResizeMode)
         return;
     d->resizeMode = newResizeMode;
+    if (newResizeMode != ManualResize)
+        resize(newResizeMode);
     Q_EMIT resizeModeChanged();
 }
 


### PR DESCRIPTION
new mode should apply instantly;
otherwise would result in:
surface created but invisible, manual resize => become visible, sizefrom => size still 0