### PR TITLE
Fix: reset qwobj's associated owner to nullptr on destruction

### DIFF
--- a/src/server/kernel/wcursor.cpp
+++ b/src/server/kernel/wcursor.cpp
@@ -59,7 +59,7 @@ WCursorPrivate::WCursorPrivate(WCursor *qq)
 
 WCursorPrivate::~WCursorPrivate()
 {
-    handle->setData(this, nullptr);
+    handle->setData(nullptr, nullptr);
     if (seat)
         seat->setCursor(nullptr);
 

--- a/src/server/kernel/winputdevice.cpp
+++ b/src/server/kernel/winputdevice.cpp
@@ -28,7 +28,7 @@ public:
         this->handle->setData(this, qq);
     }
     ~WInputDevicePrivate() {
-        handle->setData(this, nullptr);
+        handle->setData(nullptr, nullptr);
         if (seat)
             seat->detachInputDevice(q_func());
     }

--- a/src/server/kernel/wlayersurface.cpp
+++ b/src/server/kernel/wlayersurface.cpp
@@ -86,7 +86,7 @@ WLayerSurfacePrivate::WLayerSurfacePrivate(WLayerSurface *qq, QWLayerSurfaceV1 *
 WLayerSurfacePrivate::~WLayerSurfacePrivate()
 {
     if (handle)
-        handle->setData(this, nullptr);
+        handle->setData(nullptr, nullptr);
     surface->removeAttachedData<WLayerSurface>();
 }
 

--- a/src/server/kernel/woutput.cpp
+++ b/src/server/kernel/woutput.cpp
@@ -79,7 +79,7 @@ public:
     }
 
     ~WOutputPrivate() {
-        handle->setData(this, nullptr);
+        handle->setData(nullptr, nullptr);
         if (layout)
             layout->remove(q_func());
     }

--- a/src/server/kernel/wseat.cpp
+++ b/src/server/kernel/wseat.cpp
@@ -1133,7 +1133,7 @@ void WSeat::destroy(WServer *)
         setCursor(nullptr);
 
     if (m_handle) {
-        d->handle()->setData(this, nullptr);
+        d->handle()->setData(nullptr, nullptr);
         m_handle = nullptr;
     }
 }

--- a/src/server/kernel/wsurface.cpp
+++ b/src/server/kernel/wsurface.cpp
@@ -36,7 +36,7 @@ WSurfacePrivate::WSurfacePrivate(WSurface *qq, QWSurface *handle)
 WSurfacePrivate::~WSurfacePrivate()
 {
     if (handle)
-        handle->setData(this, nullptr);
+        handle->setData(nullptr, nullptr);
 
     if (buffer)
         buffer->unlock();

--- a/src/server/kernel/wxdgsurface.cpp
+++ b/src/server/kernel/wxdgsurface.cpp
@@ -72,7 +72,7 @@ WXdgSurfacePrivate::WXdgSurfacePrivate(WXdgSurface *qq, QWXdgSurface *hh)
 WXdgSurfacePrivate::~WXdgSurfacePrivate()
 {
     if (handle)
-        handle->setData(this, nullptr);
+        handle->setData(nullptr, nullptr);
     surface->removeAttachedData<WXdgSurface>();
 }
 

--- a/src/server/kernel/wxwaylandsurface.cpp
+++ b/src/server/kernel/wxwaylandsurface.cpp
@@ -76,7 +76,7 @@ public:
 WXWaylandSurfacePrivate::~WXWaylandSurfacePrivate()
 {
     if (handle)
-        handle->setData(this, nullptr);
+        handle->setData(nullptr, nullptr);
     if (surface)
         surface->removeAttachedData<WXWaylandSurface>();
 }


### PR DESCRIPTION
gtk4 re-use same wsurface for popup, so reset qwsurface's associated owner
fix https://github.com/linuxdeepin/treeland/issues/192