### PR TITLE
fix: backend not start in renderer test

### DIFF
--- a/src/server/qtquick/wrenderhelper.cpp
+++ b/src/server/qtquick/wrenderhelper.cpp
@@ -656,6 +656,8 @@ void WRenderHelper::setupRendererBackend(QWBackend *testBackend)
 
             if (!testBackend)
                 qFatal("Failed to create wlr_backend");
+
+            testBackend->start();
         }
         QQuickWindow::setGraphicsApi(WRenderHelper::probe(testBackend, apiList));
     } else if (wlrRenderer == "gles2") {


### PR DESCRIPTION
fix crash in wayland backend, backend_destroy will called when wl_display destroy, but never run start_backend