### PR TITLE
Fix: add method to init seat's keyboard focus window

### DIFF
--- a/src/server/qtquick/private/wquickseat.cpp
+++ b/src/server/qtquick/private/wquickseat.cpp
@@ -167,6 +167,12 @@ void WQuickSeat::setKeyboardFocus(WSurface *newKeyboardFocus)
     Q_EMIT keyboardFocusChanged();
 }
 
+void WQuickSeat::setKeyboardFocusWindow(QWindow *window)
+{
+    W_D(WQuickSeat);
+    d->seat->setKeyboardFocusTarget(window);
+}
+
 void WQuickSeat::addDevice(WInputDevice *device)
 {
     W_D(WQuickSeat);

--- a/src/server/qtquick/private/wquickseat_p.h
+++ b/src/server/qtquick/private/wquickseat_p.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <wquickwaylandserver.h>
+#include <QWindow>
 
 Q_MOC_INCLUDE(<wseat.h>)
 Q_MOC_INCLUDE(<wquickcursor.h>)
@@ -44,6 +45,8 @@ public:
 
     WSurface *keyboardFocus() const;
     void setKeyboardFocus(WSurface *newKeyboardFocus);
+
+    Q_INVOKABLE void setKeyboardFocusWindow(QWindow *window);
 
 public Q_SLOTS:
     void addDevice(WInputDevice *device);


### PR DESCRIPTION
currently only after mouse event can setKeyboardFocusTarget be called to init, prior keyboard is not functioning