### PR TITLE
Fix subsurface destroy

### DIFF
--- a/src/server/kernel/private/wsurface_p.h
+++ b/src/server/kernel/private/wsurface_p.h
@@ -51,6 +51,7 @@ public:
     QPointer<QW_NAMESPACE::QWSurface> handle;
     QPointer<QW_NAMESPACE::QWSubsurface> subsurface;
     bool hasSubsurface = false;
+    bool isSubsurface = false;  // qpointer would be null due to qwsubsurface' destroy, cache here
     uint32_t preferredBufferScale = 1;
     uint32_t explicitPreferredBufferScale = 0;
 

--- a/src/server/kernel/wsurface.cpp
+++ b/src/server/kernel/wsurface.cpp
@@ -206,7 +206,10 @@ void WSurfacePrivate::setSubsurface(QWSubsurface *newSubsurface)
     subsurface = newSubsurface;
     QObject::connect(subsurface, &QWSubsurface::destroyed, q, &WSurface::isSubsurfaceChanged);
 
-    Q_EMIT q->isSubsurfaceChanged();
+    if (isSubsurface != !subsurface.isNull()){
+        isSubsurface = !subsurface.isNull();
+        Q_EMIT q->isSubsurfaceChanged();
+    }
 }
 
 void WSurfacePrivate::setHasSubsurface(bool newHasSubsurface)
@@ -393,7 +396,7 @@ WOutput *WSurface::primaryOutput() const
 bool WSurface::isSubsurface() const
 {
     W_DC(WSurface);
-    return d->subsurface;
+    return d->isSubsurface;
 }
 
 bool WSurface::hasSubsurface() const

--- a/tests/manual/subsurface/Main.qml
+++ b/tests/manual/subsurface/Main.qml
@@ -61,13 +61,23 @@ Window {
         height: 200
         color: "yellow"
 
-        Button {
+        Column {
             anchors.centerIn: parent
-            text: "Add"
-            onClicked: {
-                window4.createObject()
+            property CustomWindow winObj
+            Button {
+                text: "Add"
+                onClicked: {
+                    parent.winObj = window4.createObject()
+                }
+            }
+            Button {
+                text: "Destroy"
+                onClicked: {
+                    console.log('destroying',parent.winObj,parent.winObj.close())
+                }
             }
         }
+
     }
 
     Component {

--- a/tests/manual/subsurface/window.h
+++ b/tests/manual/subsurface/window.h
@@ -18,6 +18,11 @@ public:
 
     QWindow *parent() const;
     void setParent(QWindow *newParent);
+    Q_INVOKABLE inline bool destroy() {
+        // can't close with parent, setParent(nullptr) destroys subsurf and make new xdgsurface
+        QQuickWindow::destroy();
+        return true;
+    }
 
 signals:
     void parentChanged();


### PR DESCRIPTION
Subsurface's surfaceItem itself not actively destroyed, use cases like GTK3 (firefox, d-feet)