### PR TITLE
Fix: xwayland not show since lack initial configure

### DIFF
--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -249,6 +249,7 @@ public:
         updateFrameDoneConnection();
         updateSurfaceState();
         tp()->updateTexture();
+        q->rendered = true;
     }
 
     void updateFrameDoneConnection() {


### PR DESCRIPTION
xwayland surfaceItemContent is sized 0x0 since only one commit happens, and the contentContainer is not setSized by the sizeFromSurface policy