### PR TITLE
Fix firefox popup

### DIFF
--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -892,7 +892,8 @@ void WSurfaceItem::releaseResources()
             // subsurface's contents at the last frame buffer.
             // AutoDestroy: disconnects (subsurfaceItem.surface, destroyed, this, lambda{deleteLater})
             bool disconnAutoDestroy = QObject::disconnect(item->surface(), &WSurface::destroyed, this, nullptr);
-            Q_ASSERT(disconnAutoDestroy);
+            Q_ASSERT( disconnAutoDestroy || item->property("_autoDestroyReleased").toBool() );
+            item->setProperty("_autoDestroyReleased", true);
         }
     } else {
         for (auto item : d->subsurfaces)


### PR DESCRIPTION
-  updateFrameDone when window changed, window may change, or is initialized late
- releaseResources is override func, may be called multiple times both by qt and us