### PR TITLE
Fix: sync tinywl-qtquick to use client-driven resize

### DIFF
--- a/examples/tinywl/StackToplevelHelper.qml
+++ b/examples/tinywl/StackToplevelHelper.qml
@@ -70,8 +70,7 @@ Item {
         value: {
             if (!surface.effectiveVisible)
                 return SurfaceItem.ManualResize
-            if (Helper.resizingItem === surface
-                    || stateTransition.running
+            if (stateTransition.running
                     || waylandSurface.isMaximized)
                 return SurfaceItem.SizeToSurface
             return SurfaceItem.SizeFromSurface

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -406,7 +406,7 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *watched, QInputEvent *even
 
                 if (surface->checkNewSize(geo.size().toSize())) {
                     surfaceItem->setPosition(geo.topLeft());
-                    surfaceItem->setSize(geo.size());
+                    surfaceItem->resizeSurface(geo.size().toSize());
                 }
             }
 


### PR DESCRIPTION
complement of https://github.com/vioken/waylib/pull/308

              > Should sync example/tinywl-qtquick with a new PR.

@ZhongYic00

_Originally posted by @zccrs in https://github.com/vioken/waylib/issues/308#issuecomment-2124321308_