### PR TITLE
fix: In the case of linking the ASAN library, compositor terminate on startup with client.

### DIFF
--- a/src/server/qtquick/woutputlayoutitem.cpp
+++ b/src/server/qtquick/woutputlayoutitem.cpp
@@ -31,10 +31,10 @@ public:
 
         bool changed = false;
 
-        for (auto o : outputs) {
-            if (oldOutputs.removeOne(o))
+        for (int i = 0; i < outputs.count(); i++) {
+            if (oldOutputs.removeOne(outputs.at(i)))
                 continue;
-            Q_EMIT q->enterOutput(o);
+            Q_EMIT q->enterOutput(outputs.at(i));
             changed = true;
         }
 
@@ -97,7 +97,7 @@ QList<WOutput*> WOutputLayoutItem::outputs() const
     W_DC(WOutputLayoutItem);
     QList<WOutput*> outputs;
     for (const auto &output : d->outputs) {
-        outputs.append(output.get());
+        outputs.append(output);
     }
     return outputs;
 }


### PR DESCRIPTION
Fix https://github.com/linuxdeepin/treeland/issues/280