### PR TITLE
fix: Qt ASSERT: QObject::connect: unique connection requires the slot to be a pointer to a member function of a QObject subclass

### DIFF
--- a/src/server/qtquick/private/winputmethodhelper.cpp
+++ b/src/server/qtquick/private/winputmethodhelper.cpp
@@ -397,6 +397,28 @@ QString WInputMethodHelper::seatName() const
     return wseat()->name();
 }
 
+void WInputMethodHelper::connectToTI(WQuickTextInput *ti)
+{
+    connect(ti, &WQuickTextInput::enabled, this, &WInputMethodHelper::handleTIEnabled, Qt::UniqueConnection);
+    connect(ti, &WQuickTextInput::disabled, this, &WInputMethodHelper::handleTIDisabled, Qt::UniqueConnection);
+    connect(ti, &WQuickTextInput::requestLeave, ti, &WQuickTextInput::sendLeave, Qt::UniqueConnection);
+}
+
+void WInputMethodHelper::disableTI(WQuickTextInput *ti)
+{
+    Q_ASSERT(ti);
+    W_D(WInputMethodHelper);
+    if (focusedTextInput() == ti) {
+        // Should we consider the case when the same text input is disabled and then enabled at the same time.
+        auto im = inputMethod();
+        if (im) {
+            im->sendDeactivate();
+            im->sendDone();
+        }
+        setFocusedTextInput(nullptr);
+    }
+}
+
 void WInputMethodHelper::tryAddTextInput(WQuickTextInput *ti)
 {
     W_D(WInputMethodHelper);
@@ -405,19 +427,14 @@ void WInputMethodHelper::tryAddTextInput(WQuickTextInput *ti)
     d->textInputs.append(ti);
     connect(ti, &WQuickTextInput::entityAboutToDestroy, this, [this, d, ti]{
         d->textInputs.removeAll(ti);
-        handleTIDisabled(ti);
+        disableTI(ti);
         ti->disconnect();
         ti->deleteLater();
     }); // textInputs only save and traverse text inputs, do not handle connections
-    auto connectToTI = [this](WQuickTextInput *ti) {
-        connect(ti, &WQuickTextInput::enabled, this, &WInputMethodHelper::handleTIEnabled, Qt::UniqueConnection);
-        connect(ti, &WQuickTextInput::disabled, this, [this, ti]{ handleTIDisabled(ti); }, Qt::UniqueConnection);
-        connect(ti, &WQuickTextInput::requestLeave, ti, &WQuickTextInput::sendLeave, Qt::UniqueConnection);
-    };
     // Whether this text input belongs to current seat or not, we should connect
     // its requestFocus signal for it might request focus from another seat to activate
     // itself here. For example, text input v1.
-    connect(ti, &WQuickTextInput::requestFocus, this, [this, ti, connectToTI]{
+    connect(ti, &WQuickTextInput::requestFocus, this, [this, ti]{
         if (ti->seat() && seatName() == ti->seat()->name()) {
             connectToTI(ti);
             if (seat()->keyboardFocus()) {
@@ -456,19 +473,10 @@ void WInputMethodHelper::handleTIEnabled()
     }
 }
 
-void WInputMethodHelper::handleTIDisabled(WQuickTextInput *ti)
+void WInputMethodHelper::handleTIDisabled()
 {
-    Q_ASSERT(ti);
-    W_D(WInputMethodHelper);
-    if (focusedTextInput() == ti) {
-        // Should we consider the case when the same text input is disabled and then enabled at the same time.
-        auto im = inputMethod();
-        if (im) {
-            im->sendDeactivate();
-            im->sendDone();
-        }
-        setFocusedTextInput(nullptr);
-    }
+    WQuickTextInput *ti = qobject_cast<WQuickTextInput*>(sender());
+    disableTI(ti);
 }
 
 void WInputMethodHelper::handleFocusedTICommitted()

--- a/src/server/qtquick/private/winputmethodhelper_p.h
+++ b/src/server/qtquick/private/winputmethodhelper_p.h
@@ -103,9 +103,11 @@ private:
     void updatePopupSurface(WInputPopupV2 *popup, QRect cursorRect);
     void notifyLeave();
     void resendKeyboardFocus();
+    void connectToTI(WQuickTextInput *ti);
+    void disableTI(WQuickTextInput *ti);
     void tryAddTextInput(WQuickTextInput *ti);
     void handleTIEnabled();
-    void handleTIDisabled(WQuickTextInput *ti);
+    void handleTIDisabled();
     void handleFocusedTICommitted();
     void handleIMCommitted();
 };


### PR DESCRIPTION
https://github.com/linuxdeepin/treeland/issues/281

do not use lambda for qt signal & slot