### PR TITLE
Rename surface in WxxxSurfaceItem to shellsurface

### DIFF
--- a/examples/surface-delegate/Main.qml
+++ b/examples/surface-delegate/Main.qml
@@ -156,7 +156,7 @@ Item {
 
                         XdgSurfaceItem {
                             required property WaylandXdgSurface waylandSurface
-                            surface: waylandSurface
+                            shellSurface: waylandSurface
 
                             delegate: Rectangle {
                                 required property SurfaceItem surface
@@ -165,7 +165,7 @@ Item {
                                 color: "red"
 
                                 SurfaceItemContent {
-                                    surface: parent.surface.surface.surface
+                                    surface: parent.surface.shellSurface.surface
                                     anchors.fill: parent
                                 }
                             }

--- a/examples/tinywl/LayerSurface.qml
+++ b/examples/tinywl/LayerSurface.qml
@@ -7,7 +7,7 @@ import QtQuick.Particles
 import Tinywl
 
 Item {
-    property alias waylandSurface: surfaceItem.surface
+    property alias waylandSurface: surfaceItem.shellSurface
     property alias surfaceItem: surfaceItem
     property bool anchorWidth: false
     property bool anchorHeight: false
@@ -19,7 +19,7 @@ Item {
     property bool pendingDestroy: false
 
     id: root
-    z: zValueFormLayer(waylandSurface.layer)
+    z: zValueFormLayer((waylandSurface as WaylandLayerSurface).layer)
 
     LayerSurfaceItem {
         anchors.centerIn: parent

--- a/examples/tinywl/StackWorkspace.qml
+++ b/examples/tinywl/StackWorkspace.qml
@@ -98,6 +98,7 @@ Item {
                 anchors.fill: parent
                 z: SurfaceItem.ZOrder.ContentItem - 1
                 visible: enable
+                surface: waylandSurface
             }
 
             OutputLayoutItem {
@@ -285,7 +286,7 @@ Item {
             property var surfaceParent: root.getSurfaceItemFromWaylandSurface(waylandSurface.parentXWaylandSurface)
             property int outputCounter: 0
 
-            surface: waylandSurface
+            shellSurface: waylandSurface
             parentSurfaceItem: surfaceParent ? surfaceParent.item : null
             z: waylandSurface.bypassManager ? 1 : 0 // TODO: make to enum type
             positionMode: {
@@ -327,6 +328,7 @@ Item {
                 anchors.fill: parent
                 z: SurfaceItem.ZOrder.ContentItem - 1
                 visible: enable
+                surface: waylandSurface
             }
 
             OutputLayoutItem {
@@ -413,7 +415,7 @@ Item {
             required property WaylandInputPopupSurface popupSurface
 
             id: inputPopupSurface
-            surface: popupSurface
+            shellSurface: popupSurface
             helper: inputMethodHelper
         }
     }

--- a/examples/tinywl/TiledWorkspace.qml
+++ b/examples/tinywl/TiledWorkspace.qml
@@ -215,7 +215,7 @@ Item {
                 required property XWaylandSurface waylandSurface
                 property var doDestroy: helper.doDestroy
 
-                surface: waylandSurface
+                shellSurface: waylandSurface
                 resizeMode: SurfaceItem.SizeToSurface
                 // TODO: Support popup/menu
                 positionMode: xwaylandSurfaceItem.effectiveVisible ? XWaylandSurfaceItem.PositionToSurface : XWaylandSurfaceItem.ManualPosition
@@ -281,7 +281,7 @@ Item {
             required property WaylandInputPopupSurface popupSurface
 
             id: inputPopupSurface
-            surface: popupSurface
+            shellSurface: popupSurface
             helper: inputMethodHelper
         }
     }

--- a/examples/tinywl/WindowDecoration.qml
+++ b/examples/tinywl/WindowDecoration.qml
@@ -18,6 +18,7 @@ Item {
     readonly property real bottomMargin: 0
     readonly property real leftMargin: 0
     readonly property real rightMargin: 0
+    required property ToplevelSurface surface
 
     MouseArea {
         property int edges: 0

--- a/examples/tinywl/XdgSurface.qml
+++ b/examples/tinywl/XdgSurface.qml
@@ -9,5 +9,5 @@ XdgSurfaceItem {
     required property WaylandXdgSurface waylandSurface
     property string type
 
-    surface: waylandSurface
+    shellSurface: waylandSurface
 }

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -425,12 +425,11 @@ bool Helper::afterHandleEvent(WSeat *seat, WSurface *watched, QObject *surfaceIt
 
     if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::TouchBegin) {
         // surfaceItem is qml type: XdgSurfaceItem or LayerSurfaceItem
-        auto *toplevelSurface = qvariant_cast<WToplevelSurface*>(surfaceItem->property("surface"));
-
+        auto toplevelSurface = qobject_cast<WSurfaceItem*>(surfaceItem)->shellSurface();
         if (!toplevelSurface)
             return false;
         Q_ASSERT(toplevelSurface->surface() == watched);
-        if (auto *xdgSurface = qvariant_cast<WXdgSurface*>(surfaceItem->property("surface"))) {
+        if (auto *xdgSurface = qobject_cast<WXdgSurface *>(toplevelSurface)) {
             // TODO: popupSurface should not inherit WToplevelSurface
             if (xdgSurface->isPopup()) {
                 return false;

--- a/src/server/qtquick/private/wquickinputmethodv2.cpp
+++ b/src/server/qtquick/private/wquickinputmethodv2.cpp
@@ -314,22 +314,7 @@ bool WInputPopupV2::checkNewSize(const QSize &size)
 
 WInputPopupV2Item::WInputPopupV2Item(QQuickItem *parent)
     : WSurfaceItem(parent)
-    , m_inputPopupSurface(nullptr)
 { }
-
-WInputPopupV2 *WInputPopupV2Item::surface() const
-{
-    return m_inputPopupSurface;
-}
-
-void WInputPopupV2Item::setSurface(WInputPopupV2 *surface)
-{
-    if (m_inputPopupSurface == surface)
-        return;
-    m_inputPopupSurface = surface;
-    WSurfaceItem::setSurface(surface ? surface->surface() : nullptr);
-    Q_EMIT this->surfaceChanged();
-}
 
 QString WQuickInputMethodV2::commitString() const
 {

--- a/src/server/qtquick/private/wquickinputmethodv2_p.h
+++ b/src/server/qtquick/private/wquickinputmethodv2_p.h
@@ -93,20 +93,10 @@ protected:
 class WInputPopupV2Item : public WSurfaceItem
 {
     Q_OBJECT
-    Q_PROPERTY(WInputPopupV2* surface READ surface WRITE setSurface NOTIFY surfaceChanged FINAL REQUIRED)
     QML_NAMED_ELEMENT(InputPopupSurfaceItem)
 
 public:
     explicit WInputPopupV2Item(QQuickItem *parent = nullptr);
-
-    WInputPopupV2 *surface() const;
-    void setSurface(WInputPopupV2 *surface);
-
-Q_SIGNALS:
-    void surfaceChanged();
-
-private:
-    WInputPopupV2 *m_inputPopupSurface;
 };
 
 class WQuickInputMethodKeyboardGrabV2 : public QObject, public WObject

--- a/src/server/qtquick/private/wquicklayershell.cpp
+++ b/src/server/qtquick/private/wquicklayershell.cpp
@@ -102,22 +102,6 @@ WLayerSurfaceItem::~WLayerSurfaceItem()
 
 }
 
-WLayerSurface *WLayerSurfaceItem::surface() const
-{
-    return m_surface;
-}
-
-void WLayerSurfaceItem::setSurface(WLayerSurface *surface)
-{
-    if (m_surface == surface)
-        return;
-
-    m_surface = surface;
-    WSurfaceItem::setSurface(surface ? surface->surface() : nullptr);
-
-    Q_EMIT surfaceChanged();
-}
-
 inline static int32_t getValidSize(int32_t size, int32_t fallback) {
     return size > 0 ? size : fallback;
 }
@@ -130,23 +114,23 @@ void WLayerSurfaceItem::onSurfaceCommit()
 void WLayerSurfaceItem::initSurface()
 {
     WSurfaceItem::initSurface();
-    Q_ASSERT(m_surface);
-    connect(m_surface, &WWrapObject::aboutToBeInvalidated,
+    Q_ASSERT(layerSurface());
+    connect(layerSurface(), &WWrapObject::aboutToBeInvalidated,
             this, &WLayerSurfaceItem::releaseResources);
 }
 
 bool WLayerSurfaceItem::resizeSurface(const QSize &newSize)
 {
-    if (!m_surface->checkNewSize(newSize))
+    if (!layerSurface()->checkNewSize(newSize))
        return false;
-    m_surface->configureSize(newSize);
+    layerSurface()->configureSize(newSize);
 
     return true;
 }
 
 QRectF WLayerSurfaceItem::getContentGeometry() const
 {
-   return m_surface->getContentGeometry();
+   return layerSurface()->getContentGeometry();
 }
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquicklayershell_p.h
+++ b/src/server/qtquick/private/wquicklayershell_p.h
@@ -33,28 +33,19 @@ private:
 class WAYLIB_SERVER_EXPORT WLayerSurfaceItem : public WSurfaceItem
 {
     Q_OBJECT
-    Q_PROPERTY(WLayerSurface* surface READ surface WRITE setSurface NOTIFY surfaceChanged)
-
     QML_NAMED_ELEMENT(LayerSurfaceItem)
 
 public:
     explicit WLayerSurfaceItem(QQuickItem *parent = nullptr);
     ~WLayerSurfaceItem();
 
-    WLayerSurface *surface() const;
-    void setSurface(WLayerSurface *surface);
+    inline WLayerSurface* layerSurface() const { return qobject_cast<WLayerSurface*>(shellSurface()); }
     bool resizeSurface(const QSize &newSize) override;
-
-Q_SIGNALS:
-    void surfaceChanged();
 
 private:
     Q_SLOT void onSurfaceCommit() override;
     void initSurface() override;
     QRectF getContentGeometry() const override;
-
-private:
-    QPointer<WLayerSurface> m_surface;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/private/wquickxdgshell.cpp
+++ b/src/server/qtquick/private/wquickxdgshell.cpp
@@ -96,22 +96,6 @@ WXdgSurfaceItem::~WXdgSurfaceItem()
 
 }
 
-WXdgSurface *WXdgSurfaceItem::surface() const
-{
-    return m_surface;
-}
-
-void WXdgSurfaceItem::setSurface(WXdgSurface *surface)
-{
-    if (m_surface == surface)
-        return;
-
-    m_surface = surface;
-    WSurfaceItem::setSurface(surface ? surface->surface() : nullptr);
-
-    Q_EMIT surfaceChanged();
-}
-
 QPointF WXdgSurfaceItem::implicitPosition() const
 {
     return m_implicitPosition;
@@ -134,10 +118,10 @@ inline static int32_t getValidSize(int32_t size, int32_t fallback) {
 void WXdgSurfaceItem::onSurfaceCommit()
 {
     WSurfaceItem::onSurfaceCommit();
-    if (auto popup = m_surface->handle()->toPopup()) {
+    if (auto popup = xdgSurface()->handle()->toPopup()) {
         Q_UNUSED(popup);
-        setImplicitPosition(m_surface->getPopupPosition());
-    } else if (auto toplevel = m_surface->handle()->topToplevel()) {
+        setImplicitPosition(xdgSurface()->getPopupPosition());
+    } else if (auto toplevel = xdgSurface()->handle()->topToplevel()) {
         const QSize minSize(getValidSize(toplevel->handle()->current.min_width, 0),
                             getValidSize(toplevel->handle()->current.min_height, 0));
         const QSize maxSize(getValidSize(toplevel->handle()->current.max_width, INT_MAX),
@@ -158,22 +142,22 @@ void WXdgSurfaceItem::onSurfaceCommit()
 void WXdgSurfaceItem::initSurface()
 {
     WSurfaceItem::initSurface();
-    Q_ASSERT(m_surface);
-    connect(m_surface, &WWrapObject::aboutToBeInvalidated,
+    Q_ASSERT(xdgSurface());
+    connect(xdgSurface(), &WWrapObject::aboutToBeInvalidated,
             this, &WXdgSurfaceItem::releaseResources);
 }
 
 bool WXdgSurfaceItem::resizeSurface(const QSize &newSize)
 {
-    if (!m_surface->checkNewSize(newSize))
+    if (!xdgSurface()->checkNewSize(newSize))
         return false;
-    m_surface->resize(newSize);
+    xdgSurface()->resize(newSize);
     return true;
 }
 
 QRectF WXdgSurfaceItem::getContentGeometry() const
 {
-    return m_surface->getContentGeometry();
+    return xdgSurface()->getContentGeometry();
 }
 
 void WXdgSurfaceItem::setImplicitPosition(const QPointF &newImplicitPosition)

--- a/src/server/qtquick/private/wquickxdgshell_p.h
+++ b/src/server/qtquick/private/wquickxdgshell_p.h
@@ -21,6 +21,7 @@ WAYLIB_SERVER_BEGIN_NAMESPACE
 class WSeat;
 class WQuickSurface;
 class WXdgSurface;
+class WToplevelSurface;
 class WQuickXdgShellPrivate;
 class WAYLIB_SERVER_EXPORT WQuickXdgShell : public WQuickWaylandServerInterface, public WObject
 {
@@ -43,7 +44,6 @@ private:
 class WAYLIB_SERVER_EXPORT WXdgSurfaceItem : public WSurfaceItem
 {
     Q_OBJECT
-    Q_PROPERTY(WXdgSurface* surface READ surface WRITE setSurface NOTIFY surfaceChanged)
     Q_PROPERTY(QPointF implicitPosition READ implicitPosition NOTIFY implicitPositionChanged)
     Q_PROPERTY(QSize minimumSize READ minimumSize NOTIFY minimumSizeChanged FINAL)
     Q_PROPERTY(QSize maximumSize READ maximumSize NOTIFY maximumSizeChanged FINAL)
@@ -53,16 +53,13 @@ public:
     explicit WXdgSurfaceItem(QQuickItem *parent = nullptr);
     ~WXdgSurfaceItem();
 
-    WXdgSurface *surface() const;
-    void setSurface(WXdgSurface *surface);
-
+    inline WXdgSurface* xdgSurface() const { return qobject_cast<WXdgSurface*>(shellSurface()); }
     QPointF implicitPosition() const;
     QSize minimumSize() const;
     QSize maximumSize() const;
     bool resizeSurface(const QSize &newSize) override;
 
 Q_SIGNALS:
-    void surfaceChanged();
     void implicitPositionChanged();
     void minimumSizeChanged();
     void maximumSizeChanged();
@@ -75,7 +72,6 @@ private:
     void setImplicitPosition(const QPointF &newImplicitPosition);
 
 private:
-    QPointer<WXdgSurface> m_surface;
     QPointF m_implicitPosition;
     QSize m_minimumSize;
     QSize m_maximumSize;

--- a/src/server/qtquick/private/wquickxwayland_p.h
+++ b/src/server/qtquick/private/wquickxwayland_p.h
@@ -106,7 +106,6 @@ class WQuickObserver;
 class WAYLIB_SERVER_EXPORT WXWaylandSurfaceItem : public WSurfaceItem
 {
     Q_OBJECT
-    Q_PROPERTY(WXWaylandSurface* surface READ surface WRITE setSurface NOTIFY surfaceChanged)
     Q_PROPERTY(WXWaylandSurfaceItem* parentSurfaceItem READ parentSurfaceItem WRITE setParentSurfaceItem NOTIFY parentSurfaceItemChanged FINAL)
     Q_PROPERTY(QSize minimumSize READ minimumSize NOTIFY minimumSizeChanged FINAL)
     Q_PROPERTY(QSize maximumSize READ maximumSize NOTIFY maximumSizeChanged FINAL)
@@ -126,8 +125,8 @@ public:
     explicit WXWaylandSurfaceItem(QQuickItem *parent = nullptr);
     ~WXWaylandSurfaceItem();
 
-    WXWaylandSurface *surface() const;
-    void setSurface(WXWaylandSurface *surface);
+    inline WXWaylandSurface* xwaylandSurface() const { return qobject_cast<WXWaylandSurface*>(shellSurface()); }
+    bool setShellSurface(WToplevelSurface *surface) override;
 
     WXWaylandSurfaceItem *parentSurfaceItem() const;
     void setParentSurfaceItem(WXWaylandSurfaceItem *newParentSurfaceItem);
@@ -147,7 +146,6 @@ public:
     void setIgnoreConfigureRequest(bool newIgnoreConfigureRequest);
 
 Q_SIGNALS:
-    void surfaceChanged();
     void parentSurfaceItemChanged();
     void minimumSizeChanged();
     void maximumSizeChanged();
@@ -163,7 +161,7 @@ private:
     void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
 
     inline void checkMove(PositionMode mode) {
-        if (!m_surface || mode == ManualPosition || !isVisible())
+        if (!xwaylandSurface() || mode == ManualPosition || !isVisible())
             return;
         doMove(mode);
     }
@@ -176,7 +174,6 @@ private:
     QSize expectSurfaceSize(ResizeMode mode) const;
 
 private:
-    QPointer<WXWaylandSurface> m_surface;
     QPointer<WXWaylandSurfaceItem> m_parentSurfaceItem;
     QSize m_minimumSize;
     QSize m_maximumSize;

--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -98,6 +98,7 @@ public:
 
     Q_DECLARE_PUBLIC(WSurfaceItem)
     QPointer<WSurface> surface;
+    QPointer<WToplevelSurface> shellSurface;
     std::unique_ptr<SurfaceState> surfaceState;
     QQuickItem *contentContainer = nullptr;
     QQmlComponent *delegate = nullptr;
@@ -1297,6 +1298,28 @@ qreal WSurfaceItemPrivate::getImplicitHeight() const
         return ps.height();
 
     return surfaceState->contentGeometry.height() + ps.height();
+}
+
+
+WToplevelSurface *WSurfaceItem::shellSurface() const
+{
+    return d_func()->shellSurface;
+}
+
+bool WSurfaceItem::setShellSurface(WToplevelSurface *surface)
+{
+    Q_D(WSurfaceItem);
+    if (d->shellSurface == surface)
+        return false;
+    
+    if (d->shellSurface) {
+        bool ok = d->shellSurface->safeDisconnect(this);
+        Q_ASSERT(ok);
+    }
+    d->shellSurface = surface;
+    setSurface(surface ? surface->surface() : nullptr);
+    Q_EMIT this->shellSurfaceChanged();
+    return true;
 }
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/qtquick/wsurfaceitem.h
+++ b/src/server/qtquick/wsurfaceitem.h
@@ -5,6 +5,7 @@
 
 #include <wglobal.h>
 #include <WSurface>
+#include <wtoplevelsurface.h>
 
 #include <QQuickItem>
 
@@ -64,6 +65,7 @@ class WAYLIB_SERVER_EXPORT WSurfaceItem : public QQuickItem
     Q_OBJECT
     Q_DECLARE_PRIVATE(WSurfaceItem)
     Q_PROPERTY(WSurface* surface READ surface WRITE setSurface NOTIFY surfaceChanged)
+    Q_PROPERTY(WToplevelSurface* shellSurface READ shellSurface WRITE setShellSurface NOTIFY shellSurfaceChanged)
     Q_PROPERTY(QQuickItem* contentItem READ contentItem NOTIFY contentItemChanged)
     Q_PROPERTY(QQuickItem* eventItem READ eventItem NOTIFY eventItemChanged)
     Q_PROPERTY(ResizeMode resizeMode READ resizeMode WRITE setResizeMode NOTIFY resizeModeChanged FINAL)
@@ -112,6 +114,9 @@ public:
 
     WSurface *surface() const;
     void setSurface(WSurface *newSurface);
+
+    WToplevelSurface *shellSurface() const;
+    virtual bool setShellSurface(WToplevelSurface *surface);
 
     QQuickItem *contentItem() const;
     QQuickItem *eventItem() const;
@@ -164,6 +169,7 @@ Q_SIGNALS:
     void bufferScaleChanged();
     void contentItemChanged();
     void delegateChanged();
+    void shellSurfaceChanged();
 
 protected:
     void componentComplete() override;


### PR DESCRIPTION
- make toplevelSurface a property in WSurfaceItem
- rename `surface`  to `shellSurface` to avoid ambiguity