### PR TITLE
fix: wsurface no need to safeConnect its handle and destroyer

### DIFF
--- a/src/server/kernel/wsurface.cpp
+++ b/src/server/kernel/wsurface.cpp
@@ -188,7 +188,7 @@ WSurface *WSurfacePrivate::ensureSubsurface(wlr_subsurface *subsurface)
 
     auto qwsurface = QWSurface::from(subsurface->surface);
     auto surface = new WSurface(qwsurface, q_func());
-    surface->safeConnect(&QWSurface::beforeDestroy, surface, &WSurface::safeDeleteLater);
+    QObject::connect(surface->handle(), &QWSurface::beforeDestroy, surface, &WSurface::safeDeleteLater);
 
     return surface;
 }


### PR DESCRIPTION
"Not need to use safeConnect for the signal of self's handle object"