### PR TITLE
WQmlCreator requires WQmlEngine

### DIFF
--- a/examples/blur/helper.h
+++ b/examples/blur/helper.h
@@ -35,7 +35,7 @@ class Helper : public QObject
     QML_SINGLETON
 
 public:
-    explicit Helper(QObject *parent = nullptr);
+    explicit Helper(QQmlEngine *engine, QObject *parent = nullptr);
 
     void initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine);
 

--- a/examples/blur/main.cpp
+++ b/examples/blur/main.cpp
@@ -34,10 +34,10 @@
 
 QW_USE_NAMESPACE
 
-Helper::Helper(QObject *parent)
+Helper::Helper(QQmlEngine *engine, QObject *parent)
     : QObject(parent)
     , m_server(new WServer(this))
-    , m_outputCreator(new WQmlCreator(this))
+    , m_outputCreator(new WQmlCreator(engine, this))
     , m_outputLayout(new WQuickOutputLayout(this))
     , m_cursor(new WQuickCursor(this))
 {
@@ -128,6 +128,16 @@ int main(int argc, char *argv[]) {
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
     QGuiApplication::setQuitOnLastWindowClosed(false);
     QGuiApplication app(argc, argv);
+
+    qmlRegisterSingletonType<Helper>(
+        "Blur",
+        1,
+        0,
+        "Helper",
+        [](QQmlEngine *engine, [[maybe_unused]] QJSEngine *scriptEngine) -> QObject * {
+            Helper *helper = new Helper(engine);
+            return helper;
+        });
 
     QQmlApplicationEngine waylandEngine;
     waylandEngine.loadFromModule("Blur", "Main");

--- a/examples/outputviewport/helper.h
+++ b/examples/outputviewport/helper.h
@@ -35,7 +35,7 @@ class Helper : public QObject
     QML_SINGLETON
 
 public:
-    explicit Helper(QObject *parent = nullptr);
+    explicit Helper(QQmlEngine *engine, QObject *parent = nullptr);
 
     void initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine);
 

--- a/examples/outputviewport/main.cpp
+++ b/examples/outputviewport/main.cpp
@@ -34,10 +34,10 @@
 
 QW_USE_NAMESPACE
 
-Helper::Helper(QObject *parent)
+Helper::Helper(QQmlEngine *engine, QObject *parent)
     : QObject(parent)
     , m_server(new WServer(this))
-    , m_outputCreator(new WQmlCreator(this))
+    , m_outputCreator(new WQmlCreator(engine,this))
     , m_outputLayout(new WQuickOutputLayout(this))
     , m_cursor(new WQuickCursor(this))
 {
@@ -128,6 +128,16 @@ int main(int argc, char *argv[]) {
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
     QGuiApplication::setQuitOnLastWindowClosed(false);
     QGuiApplication app(argc, argv);
+
+    qmlRegisterSingletonType<Helper>(
+        "OutputViewport",
+        1,
+        0,
+        "Helper",
+        [](QQmlEngine *engine, [[maybe_unused]] QJSEngine *scriptEngine) -> QObject * {
+            Helper *helper = new Helper(engine);
+            return helper;
+        });
 
     QQmlApplicationEngine waylandEngine;
     waylandEngine.loadFromModule("OutputViewport", "Main");

--- a/examples/tinywl/StackWorkspace.qml
+++ b/examples/tinywl/StackWorkspace.qml
@@ -99,15 +99,14 @@ Item {
 
                 Connections {
                     target: Helper.xdgDecorationManager
-
                     function onSurfaceModeChanged(surface, mode) {
-                        if (waylandSurface === surface)
-                            visible = (mode !== XdgDecorationManager.Client)
+                        if (waylandSurface.surface === surface)
+                            decoration.visible = mode === XdgDecorationManager.Server
                     }
                 }
 
                 Component.onCompleted: {
-                    visible = Helper.xdgDecorationManager.modeBySurface(surface.surface) !== XdgDecorationManager.Client
+                    decoration.visible = Helper.xdgDecorationManager.modeBySurface(waylandSurface.surface) === XdgDecorationManager.Server
                 }
             }
 

--- a/examples/tinywl/helper.h
+++ b/examples/tinywl/helper.h
@@ -17,6 +17,10 @@
 
 #include <QList>
 
+Q_MOC_INCLUDE(<woutputrenderwindow.h>)
+Q_MOC_INCLUDE(<wqmlcreator.h>)
+Q_MOC_INCLUDE(<qwcompositor.h>)
+
 Q_DECLARE_OPAQUE_POINTER(QWindow*)
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
@@ -60,7 +64,7 @@ class Helper : public WSeatEventFilter {
     QML_SINGLETON
 
 public:
-    explicit Helper(QObject *parent = nullptr);
+    explicit Helper(QQmlEngine *engine, QObject *parent = nullptr);
 
     void initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine);
     WQuickOutputLayout *outputLayout() const;
@@ -177,7 +181,3 @@ struct OutputInfo {
     quint32 m_rightExclusiveMargin = 0;
     QList<std::tuple<WLayerSurface*, uint32_t, WLayerSurface::AnchorType>> registeredSurfaceList;
 };
-
-Q_DECLARE_OPAQUE_POINTER(WAYLIB_SERVER_NAMESPACE::WOutputRenderWindow*)
-Q_DECLARE_OPAQUE_POINTER(WAYLIB_SERVER_NAMESPACE::WQmlCreator*)
-Q_DECLARE_OPAQUE_POINTER(QW_NAMESPACE::QWCompositor*)

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -68,17 +68,17 @@ inline QPointF getItemGlobalPosition(QQuickItem *item)
     return parent ? parent->mapToGlobal(item->position()) : item->position();
 }
 
-Helper::Helper(QObject *parent)
+Helper::Helper(QQmlEngine *engine, QObject *parent)
     : WSeatEventFilter(parent)
     , m_server(new WServer(this))
     , m_outputLayout(new WQuickOutputLayout(this))
     , m_cursor(new WQuickCursor(this))
     , m_seat(new WSeat())
-    , m_outputCreator(new WQmlCreator(this))
-    , m_xdgShellCreator(new WQmlCreator(this))
-    , m_xwaylandCreator(new WQmlCreator(this))
-    , m_layerShellCreator(new WQmlCreator(this))
-    , m_inputPopupCreator(new WQmlCreator(this))
+    , m_outputCreator(new WQmlCreator(engine, this))
+    , m_xdgShellCreator(new WQmlCreator(engine, this))
+    , m_xwaylandCreator(new WQmlCreator(engine, this))
+    , m_layerShellCreator(new WQmlCreator(engine, this))
+    , m_inputPopupCreator(new WQmlCreator(engine, this))
 {
     m_seat->setEventFilter(this);
     m_seat->setCursor(m_cursor);
@@ -804,6 +804,16 @@ int main(int argc, char *argv[]) {
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
     QGuiApplication::setQuitOnLastWindowClosed(false);
     QGuiApplication app(argc, argv);
+
+    qmlRegisterSingletonType<Helper>(
+        "Tinywl",
+        1,
+        0,
+        "Helper",
+        [](QQmlEngine *engine, [[maybe_unused]] QJSEngine *scriptEngine) -> QObject * {
+            Helper *helper = new Helper(engine);
+            return helper;
+        });
 
     QQmlApplicationEngine waylandEngine;
 

--- a/src/server/qtquick/wqmlcreator.cpp
+++ b/src/server/qtquick/wqmlcreator.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wqmlcreator_p.h"
-#include "wxdgsurface.h"
 
 #include <QJSValue>
 #include <QQuickItem>
@@ -353,9 +352,10 @@ void WQmlCreatorComponent::setAutoDestroy(bool newAutoDestroy)
     Q_EMIT autoDestroyChanged();
 }
 
-WQmlCreator::WQmlCreator(QObject *parent)
+WQmlCreator::WQmlCreator(QQmlEngine *engine, QObject *parent)
     : QObject{parent}
     , WObject(*new WQmlCreatorPrivate(this))
+    , m_engine(engine)
 {
 
 }

--- a/src/server/qtquick/wqmlcreator.h
+++ b/src/server/qtquick/wqmlcreator.h
@@ -58,9 +58,10 @@ class WAYLIB_SERVER_EXPORT WQmlCreator : public QObject, public WObject
     Q_OBJECT
     Q_PROPERTY(int count READ count NOTIFY countChanged FINAL)
     QML_NAMED_ELEMENT(DynamicCreator)
+    QML_UNCREATABLE("Can't create in QML")
 
 public:
-    explicit WQmlCreator(QObject *parent = nullptr);
+    explicit WQmlCreator(QQmlEngine *entine, QObject *parent = nullptr);
     ~WQmlCreator();
 
     QList<WAbstractCreatorComponent *> delegates() const;
@@ -103,6 +104,8 @@ private:
     void removeDelegate(WAbstractCreatorComponent *delegate);
 
     friend class WAbstractCreatorComponent;
+
+    QQmlEngine *m_engine;
 };
 
 WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
WQmlCreator has the ability to execute qml js methods, but WQmlCreator is not a child of QmlEngine, so the previous qmlEngine method will not be available. For this reason, the helper is manually registered as a QML singleton object.