### PR TITLE
fix: new output viewport does not render

### DIFF
--- a/src/server/qtquick/woutputhelper.cpp
+++ b/src/server/qtquick/woutputhelper.cpp
@@ -35,13 +35,13 @@ WAYLIB_SERVER_BEGIN_NAMESPACE
 class WOutputHelperPrivate : public WObjectPrivate
 {
 public:
-    WOutputHelperPrivate(WOutput *output, WOutputHelper *qq)
+    WOutputHelperPrivate(WOutput *output, WOutputHelper *qq, bool r/* renderable */, bool c /*contentIsDirty*/, bool n/*needsFrame*/)
         : WObjectPrivate(qq)
         , output(output)
         , outputWindow(new QW::Window)
-        , renderable(false)
-        , contentIsDirty(false)
-        , needsFrame(false)
+        , renderable(r)
+        , contentIsDirty(c)
+        , needsFrame(n)
     {
         wlr_output_state_init(&state);
 
@@ -152,9 +152,14 @@ QWBuffer *WOutputHelperPrivate::acquireBuffer(wlr_swapchain **sc, int *bufferAge
     return newBuffer;
 }
 
-WOutputHelper::WOutputHelper(WOutput *output, QObject *parent)
+WOutputHelper::WOutputHelper(WOutput *output, bool renderable, bool contentIsDirty, bool needsFrame, QObject *parent)
     : QObject(parent)
-    , WObject(*new WOutputHelperPrivate(output, this))
+    , WObject(*new WOutputHelperPrivate(output, this, renderable, contentIsDirty, needsFrame))
+{
+}
+
+WOutputHelper::WOutputHelper(WOutput *output, QObject *parent)
+    : WOutputHelper(output, false, false, false, parent)
 {
 
 }

--- a/src/server/qtquick/woutputhelper.h
+++ b/src/server/qtquick/woutputhelper.h
@@ -69,6 +69,9 @@ public:
     void resetState(bool resetRenderable);
     void update();
 
+protected:
+    WOutputHelper(WOutput *output, bool renderable, bool contentIsDirty, bool needsFrame, QObject *parent = nullptr);
+
 Q_SIGNALS:
     void requestRender();
     void damaged();


### PR DESCRIPTION
Frame might have been accepted by old viewport with the same output, if old output viewport is frozen. Then no one will handle frame. Just copy pending state.