### PR TITLE
Fix duplication setting ouput setLayout

### DIFF
--- a/src/server/qtquick/wquickoutputlayout.cpp
+++ b/src/server/qtquick/wquickoutputlayout.cpp
@@ -76,7 +76,6 @@ void WQuickOutputLayout::remove(WOutputItem *output)
 
     if (auto o = output->output()) {
         remove(o);
-        o->setLayout(nullptr);
     }
 
     Q_EMIT outputsChanged();


### PR DESCRIPTION
Because setLayout(nullptr) is executed in WOutputLayout::remove, there is no need to set setLayout repeatedly.