### PR TITLE
Fix Unplug screen crash

### DIFF
--- a/src/server/qtquick/wqmlcreator.cpp
+++ b/src/server/qtquick/wqmlcreator.cpp
@@ -159,8 +159,11 @@ void WQmlCreatorComponent::destroy(QSharedPointer<WQmlCreatorDelegateData> data)
         Q_EMIT objectRemoved(obj, p);
         notifyCreatorObjectRemoved(creator(), obj, p);
 
-        if (m_autoDestroy)
-            obj->deleteLater();
+        if (m_autoDestroy) {
+            obj->setParent(nullptr);
+            delete obj;
+            obj = nullptr;
+        }
     }
 }
 


### PR DESCRIPTION
Use delete to replace deleteLater() to solve the asynchronous destruction delay problem.