### PR TITLE
fix: QWlrootsScreen::refreshRate error

### DIFF
--- a/src/server/platformplugin/qwlrootscreen.cpp
+++ b/src/server/platformplugin/qwlrootscreen.cpp
@@ -74,7 +74,7 @@ qreal QWlrootsScreen::refreshRate() const
 {
     if (!handle()->current_mode)
         return 60;
-    return handle()->current_mode->refresh;
+    return handle()->current_mode->refresh / 1000.f;
 }
 
 QDpi QWlrootsScreen::logicalBaseDpi() const


### PR DESCRIPTION
qt refreshRate mean refresh rate of the screen in Hz, but wlr_output_mode's refresh is mHz.