### PR TITLE
Drop unnecessary codes

### DIFF
--- a/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/src/server/qtquick/private/wbufferrenderer.cpp
@@ -123,9 +123,8 @@ public:
         return m_texture ? m_texture->buffer : nullptr;
     }
 
-    void setBuffer(qw_buffer *buffer, const pixman_region32_t *damage = nullptr) {
+    void setBuffer(qw_buffer *buffer) {
         if (buffer && buffer == qwBuffer()) {
-            m_texture->qwtexture->update_from_buffer(*buffer, damage);
             Q_EMIT textureChanged();
             return;
         }
@@ -676,7 +675,7 @@ void WBufferRenderer::render(int sourceIndex, const QMatrix4x4 &renderMatrix,
     }
 
     if (shouldCacheBuffer())
-        m_textureProvider->setBuffer(state.buffer, &m_damageRing.handle()->current);
+        m_textureProvider->setBuffer(state.buffer);
 }
 
 void WBufferRenderer::endRender()


### PR DESCRIPTION
update_from_buffer function is using for the pixman image data update to OpenGL texture case, the qw_buffer of WBufferRenderer is allot from qw_swapchain, it's a dmabuf, not needs update_from_buffer after render on this buffer.