### PR TITLE
Fix crash on application quit

### DIFF
--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -1264,11 +1264,10 @@ void WSurfaceItemPrivate::updateEventItem(bool forceDestroy)
         return;
 
     if (auto eventItemTmp = eventItem) {
-        // set evItem's parentItem to null will invoke clearFocusInScope then focusIn surfaceItem
-        // first clear eventItem to avoid forceActiveFocus on eventItem again
+        // maybe trigger QQuickDeliveryAgentPrivate::clearFocusInScope in later,
+        // first clear eventItem=nullptr to avoid forceActiveFocus on eventItem again.
         this->eventItem = nullptr;
         eventItemTmp->setVisible(false);
-        eventItemTmp->setParentItem(nullptr);
         eventItemTmp->setParent(nullptr);
         eventItemTmp->deleteLater();
     } else {


### PR DESCRIPTION
setParentItem(nullptr) maybe lead to
QQuickDeliveryAgentPrivate::clearFocusInScope, Qt wants emit QQuickItem::window()->focusObjectChanged signal, but the window of that item is nullptr now.