### PR TITLE
Fix black screen for setting replication mode

### DIFF
--- a/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/src/server/qtquick/private/wbufferrenderer.cpp
@@ -489,6 +489,9 @@ qw_buffer *WBufferRenderer::beginRender(const QSize &pixelSize, qreal devicePixe
     state.renderTarget = rt;
     state.sgRenderTarget = sgRT;
 
+    if (!shouldCacheBuffer())
+        m_textureProvider->setBuffer(buffer);
+
     return buffer;
 }
 


### PR DESCRIPTION
beginRender is caused when the texture is not updated