### PR TITLE
Fix multiple cursor

### DIFF
--- a/src/server/kernel/wcursor.cpp
+++ b/src/server/kernel/wcursor.cpp
@@ -652,6 +652,10 @@ void WCursor::setLayout(WOutputLayout *layout)
         o->addCursor(this);
     });
 
+    connect(d->outputLayout, &WOutputLayout::outputRemoved, this, [this, d] (WOutput *o) {
+        o->removeCursor(this);
+    });
+
     Q_EMIT layoutChanged();
 }
 

--- a/src/server/qtquick/woutputrenderwindow.cpp
+++ b/src/server/qtquick/woutputrenderwindow.cpp
@@ -246,6 +246,7 @@ private:
     QPointer<WBufferRenderer> m_cursorRenderer;
     BufferRendererProxy *m_cursorLayerProxy = nullptr;
     bool m_cursorDirty = false;
+    bool m_cursorRenderComplete = false;
 
     // for compositeLayers
     QPointer<WOutputViewport> m_output2;
@@ -826,6 +827,10 @@ WBufferRenderer *OutputHelper::afterRender()
 
     if (layers.isEmpty()) {
         cleanLayerCompositor();
+        if (m_cursorRenderComplete) {
+            tryToHardwareCursor(nullptr);
+            cleanCursorRender();
+        }
         return bufferRenderer();
     }
 
@@ -1067,8 +1072,9 @@ bool OutputHelper::tryToHardwareCursor(const LayerData *layer)
                           ? layer->renderer->lastBuffer()->handle()
                           : nullptr;
         if (!buffer) {
-            if (set_cursor)
+            if (set_cursor && m_cursorRenderComplete)
                 set_cursor(qwoutput()->handle(), buffer, 0, 0);
+            m_cursorRenderComplete = false;
             return true;
         }
 
@@ -1142,6 +1148,7 @@ bool OutputHelper::tryToHardwareCursor(const LayerData *layer)
         if (!set_cursor(qwoutput()->handle(), buffer, hotSpot.x(), hotSpot.y())) {
             break;
         } else {
+            m_cursorRenderComplete = true;
             resetGlState();
         }
 


### PR DESCRIPTION
When the cursor moves across the screen, the cursor on the first screen is not cleared, you need to call set_cursor again to clear it.