### PR TITLE
Fix crash caused by null pointer

### DIFF
--- a/src/server/qtquick/private/wquickcoordmapper.cpp
+++ b/src/server/qtquick/private/wquickcoordmapper.cpp
@@ -54,6 +54,9 @@ WQuickCoordMapper *WQuickCoordMapperHelper::get(WQuickObserver *target)
     connect(mapper, &WQuickCoordMapper::destroyed, this, [this] {
         list.removeOne(qobject_cast<WQuickCoordMapper*>(QObject::sender()));
     });
+
+    connect(target, &WQuickCoordMapper::destroyed, mapper, &WQuickCoordMapper::deleteLater);
+
     list.append(mapper);
 
     return mapper;


### PR DESCRIPTION
Destroy WQuickCoordMapper synchronously when item is destroyed