### PR TITLE
Clear up foreigntoplevelv1 and support xwayland

### DIFF
--- a/examples/tinywl/StackToplevelHelper.qml
+++ b/examples/tinywl/StackToplevelHelper.qml
@@ -139,10 +139,7 @@ Item {
         }
 
         function onRequestClose() {
-            if (waylandSurface.close) // WXWaylandSurface
-                waylandSurface.close()
-            else
-                waylandSurface.surface.unmap()
+            waylandSurface.close()
         }
     }
 

--- a/src/server/kernel/wtoplevelsurface.h
+++ b/src/server/kernel/wtoplevelsurface.h
@@ -94,6 +94,8 @@ public Q_SLOTS:
     virtual void resize(const QSize &size) {
         Q_UNUSED(size)
     }
+    virtual void close() {
+    }
 
 Q_SIGNALS:
     void activateChanged();

--- a/src/server/protocols/wforeigntoplevelv1.h
+++ b/src/server/protocols/wforeigntoplevelv1.h
@@ -14,7 +14,7 @@ Q_MOC_INCLUDE("wsurface.h")
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-class WXdgSurface;
+class WToplevelSurface;
 class WForeignToplevelPrivate;
 class WAYLIB_SERVER_EXPORT WForeignToplevel : public QObject, public WServerInterface, public WObject
 {
@@ -24,18 +24,18 @@ class WAYLIB_SERVER_EXPORT WForeignToplevel : public QObject, public WServerInte
 public:
     explicit WForeignToplevel(QObject *parent = nullptr);
 
-    void addSurface(WXdgSurface *surface);
-    void removeSurface(WXdgSurface *surface);
+    void addSurface(WToplevelSurface *surface);
+    void removeSurface(WToplevelSurface *surface);
 
     QByteArrayView interfaceName() const override;
 
 Q_SIGNALS:
-    void requestMaximize(WXdgSurface *surface, bool isMaximized);
-    void requestMinimize(WXdgSurface *surface, bool isMinimized);
-    void requestActivate(WXdgSurface *surface);
-    void requestFullscreen(WXdgSurface *surface, bool isFullscreen);
-    void requestClose(WXdgSurface *surface);
-    void rectangleChanged(WXdgSurface *surface, const QRect &rect);
+    void requestMaximize(WToplevelSurface *surface, bool isMaximized);
+    void requestMinimize(WToplevelSurface *surface, bool isMinimized);
+    void requestActivate(WToplevelSurface *surface);
+    void requestFullscreen(WToplevelSurface *surface, bool isFullscreen);
+    void requestClose(WToplevelSurface *surface);
+    void rectangleChanged(WToplevelSurface *surface, const QRect &rect);
 
 private:
     void create(WServer *server) override;

--- a/src/server/protocols/wxdgsurface.cpp
+++ b/src/server/protocols/wxdgsurface.cpp
@@ -259,6 +259,20 @@ void WXdgSurface::resize(const QSize &size)
     }
 }
 
+void WXdgSurface::close()
+{
+    W_D(WXdgSurface);
+
+    if (Q_LIKELY(isToplevel())) {
+        auto toplevel = qw_xdg_toplevel::from(d->nativeHandle()->toplevel);
+        toplevel->send_close();
+    } else if (Q_LIKELY(isPopup())) {
+        // wlr_xdg_popup_destroy will send popup_done to the client
+        // can't use delete qw_xdg_popup, which is not owner of wlr_xdg_popup
+        wlr_xdg_popup_destroy(d->nativeHandle()->popup);
+    }
+}
+
 bool WXdgSurface::isResizeing() const
 {
     W_DC(WXdgSurface);

--- a/src/server/protocols/wxdgsurface.h
+++ b/src/server/protocols/wxdgsurface.h
@@ -68,6 +68,7 @@ public Q_SLOTS:
 
     bool checkNewSize(const QSize &size) override;
     void resize(const QSize &size) override;
+    void close() override;
 
 Q_SIGNALS:
     void parentXdgSurfaceChanged();

--- a/src/server/protocols/wxwaylandsurface.h
+++ b/src/server/protocols/wxwaylandsurface.h
@@ -121,7 +121,7 @@ public Q_SLOTS:
     void setMinimize(bool on) override;
     void setFullScreen(bool on) override;
     void setActivate(bool on) override;
-    void close();
+    void close() override;
     void restack(WXWaylandSurface *sibling, StackMode mode);
 
 Q_SIGNALS:


### PR DESCRIPTION
1. fix xdg surface never closed by ssd
2. make foreigntoplevelv1 also support xwayland
3. parentSurface is not QObject's parent, and set_parent is not setParent
4. don't emit fake signal for WToplevelSurface
5. use unique_ptr to mange handle to fix handle not delete when surface remove