### PR TITLE
fix: virtual keyboard crash in creation

### DIFF
--- a/src/server/protocols/private/wvirtualkeyboardv1.cpp
+++ b/src/server/protocols/private/wvirtualkeyboardv1.cpp
@@ -37,9 +37,7 @@ void WVirtualKeyboardManagerV1::create(WServer *server)
     auto manager = qw_virtual_keyboard_manager_v1::create(*server->handle());
     Q_ASSERT(manager);
     m_handle = manager;
-    connect(manager, &qw_virtual_keyboard_manager_v1::notify_new_virtual_keyboard, this, [ this ] (wlr_virtual_keyboard_v1* keyboard) {
-        Q_EMIT newVirtualKeyboard(qw_virtual_keyboard_v1::from(keyboard));
-    });
+    connect(manager, &qw_virtual_keyboard_manager_v1::notify_new_virtual_keyboard, this, &WVirtualKeyboardManagerV1::newVirtualKeyboard);
 }
 
 wl_global *WVirtualKeyboardManagerV1::global() const

--- a/src/server/protocols/private/wvirtualkeyboardv1_p.h
+++ b/src/server/protocols/private/wvirtualkeyboardv1_p.h
@@ -8,12 +8,7 @@
 
 #include <qwglobal.h>
 
-Q_MOC_INCLUDE(<qwvirtualkeyboardv1.h>)
-
-QW_BEGIN_NAMESPACE
-class qw_virtual_keyboard_v1;
-QW_END_NAMESPACE
-
+struct wlr_virtual_keyboard_v1;
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WVirtualKeyboardManagerV1Private;
 class WAYLIB_SERVER_EXPORT WVirtualKeyboardManagerV1 : public QObject, public WObject, public WServerInterface
@@ -26,7 +21,7 @@ public:
     QByteArrayView interfaceName() const override;
 
 Q_SIGNALS:
-    void newVirtualKeyboard(QW_NAMESPACE::qw_virtual_keyboard_v1 *virtualKeyboard);
+    void newVirtualKeyboard(wlr_virtual_keyboard_v1 *virtualKeyboard);
 
 private:
     void create(WServer *server) override;

--- a/src/server/protocols/winputmethodhelper.h
+++ b/src/server/protocols/winputmethodhelper.h
@@ -18,6 +18,7 @@ class qw_input_popup_surface_v2;
 class qw_virtual_keyboard_v1;
 QW_END_NAMESPACE
 struct wlr_seat_keyboard_grab;
+struct wlr_virtual_keyboard_v1;
 struct wlr_keyboard_modifiers;
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WServer;
@@ -46,7 +47,7 @@ private:
     void handleNewIMV2(QW_NAMESPACE::qw_input_method_v2 *imv2);
     void handleNewKGV2(QW_NAMESPACE::qw_input_method_keyboard_grab_v2 *kgv2);
     void handleNewIPSV2(QW_NAMESPACE::qw_input_popup_surface_v2 *ipsv2);
-    void handleNewVKV1(QW_NAMESPACE::qw_virtual_keyboard_v1 *vkv1);
+    void handleNewVKV1(wlr_virtual_keyboard_v1 *vkv1);
     void updateAllPopupSurfaces(QRect cursorRect);
     void updatePopupSurface(WInputPopupSurface *popup, QRect cursorRect);
     void notifyLeave();


### PR DESCRIPTION
Use wlr_virtual_keyboard_v1 directly instead of wrapper for it.

Depends-on: https://github.com/vioken/qwlroots/pull/296