### PR TITLE
fix: crash when setSourceList twice

### DIFF
--- a/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/src/server/qtquick/private/wbufferrenderer.cpp
@@ -710,7 +710,9 @@ void WBufferRenderer::removeSource(int index)
     if (isRootItem(s.source))
         return;
 
-    s.renderer->deleteLater();
+    // Renderer of source is delay initialized in ensureRenderer. It might be null here.
+    if (s.renderer)
+        s.renderer->deleteLater();
     auto d = QQuickItemPrivate::get(s.source);
     if (d->inDestructor)
         return;


### PR DESCRIPTION
Renderer is delay intialized, so check if renderer is null.