### PR TITLE
fix: crash when cursor image is null

### DIFF
--- a/src/server/qtquick/wquickcursor.cpp
+++ b/src/server/qtquick/wquickcursor.cpp
@@ -577,6 +577,9 @@ QSGNode *WQuickCursor::updatePaintNode(QSGNode *node, UpdatePaintNodeData *)
     }
 
     auto texture = tp->WSGTextureProvider::texture();
+    // texture is created from cursorImage, when image is null, texture is also null
+    if (!texture)
+        return nullptr;
     auto imageNode = static_cast<QSGImageNode*>(node);
     if (!imageNode)
         imageNode = window()->createImageNode();


### PR DESCRIPTION
Check if texture is null before setting texture to image node.