### PR TITLE
Fixed multiple screen crashes

### DIFF
--- a/examples/tinywl-new/qmlengine.cpp
+++ b/examples/tinywl-new/qmlengine.cpp
@@ -139,9 +139,9 @@ QQuickItem *QmlEngine::createMenuBar(WOutputItem *output, QQuickItem *parent)
 
 WallpaperImageProvider *QmlEngine::wallpaperImageProvider()
 {
-    Q_ASSERT(!this->imageProvider("wallpaper"));
     if (!wallpaperProvider) {
         wallpaperProvider = new WallpaperImageProvider;
+        Q_ASSERT(!this->imageProvider("wallpaper"));
         addImageProvider("wallpaper", wallpaperProvider);
     }
 


### PR DESCRIPTION
should check whether the imageProvider is successfully registered before registration.