### PR TITLE
fix: qtwayland crash in treeland when enabling im

### DIFF
--- a/src/server/protocols/private/wtextinputv1.cpp
+++ b/src/server/protocols/private/wtextinputv1.cpp
@@ -144,7 +144,10 @@ IME::Features WTextInputV1::features() const
 
 void WTextInputV1::sendEnter(WSurface *surface)
 {
-    zwp_text_input_v1_send_enter(d_func()->resource, surface->handle()->handle()->resource);
+    // Note: For text input v1, activation and surface focus is managed by client.
+    // Do not send focus to text input unless it's activated.
+    if (d_func()->active)
+        zwp_text_input_v1_send_enter(d_func()->resource, surface->handle()->handle()->resource);
     Q_EMIT this->enabled();
 }
 
@@ -264,6 +267,7 @@ void text_input_handle_deactivate(wl_client *client,
         return;
 
     d->seat = nullptr;
+    d->active = false;
     Q_EMIT text_input->deactivate();
 }
 


### PR DESCRIPTION
As there's no method for client to notify server that a text input
v1 should be deleted. Text input here in compositor might be invalid
for client. Do not send enter to text input unless it's activated.
