### PR TITLE
Update ItemHasContents flag before update content

### DIFF
--- a/src/server/qtquick/wquickcursor.cpp
+++ b/src/server/qtquick/wquickcursor.cpp
@@ -234,9 +234,9 @@ void WQuickCursorPrivate::setSurface(WSurface *surface)
             cursorSurfaceItem = nullptr;
         }
     }
-
     updateImplicitSize();
-    q->update();
+    if (q->flags().testFlag(QQuickItem::ItemHasContents))
+        q->update();
 }
 
 void WQuickCursorPrivate::enterOutput(WOutput *output)

--- a/src/server/qtquick/wquickcursor.cpp
+++ b/src/server/qtquick/wquickcursor.cpp
@@ -218,8 +218,6 @@ void WQuickCursorPrivate::setSurface(WSurface *surface)
                 auto rs = this->cursor->requestedCursorSurface();
                 setHotSpot(rs.second - cursorSurfaceItem->bufferOffset());
             });
-
-            q->setFlag(QQuickItem::ItemHasContents, false);
         }
 
         cursorSurfaceItem->setSurface(surface);
@@ -235,7 +233,6 @@ void WQuickCursorPrivate::setSurface(WSurface *surface)
             cursorSurfaceItem->deleteLater();
             cursorSurfaceItem = nullptr;
         }
-        q->setFlag(QQuickItem::ItemHasContents, true);
     }
 
     updateImplicitSize();
@@ -284,21 +281,27 @@ void WQuickCursorPrivate::onImageChanged()
 
 void WQuickCursorPrivate::updateCursor()
 {
+    W_Q(WQuickCursor);
+
     auto cursor = this->cursor->cursor();
     if (WGlobal::isClientResourceCursor(cursor)) {
         // First try use cursor shape
         auto shape = this->cursor->requestedCursorShape();
         if (shape != WGlobal::CursorShape::Invalid) {
+            q->setFlag(QQuickItem::ItemHasContents, true);
             setSurface(nullptr);
             cursorImage->setCursor(WCursor::toQCursor(shape));
             setHotSpot(cursorImage->hotSpot());
         } else { // Second use cursor surface
             auto rs = this->cursor->requestedCursorSurface();
-            cursorImage->setCursor(QCursor(Qt::BlankCursor));
+            q->setFlag(QQuickItem::ItemHasContents, false);
+            dirty(QQuickItemPrivate::Content);
+
             setSurface(rs.first);
             setHotSpot(rs.second);
         }
     } else {
+        q->setFlag(QQuickItem::ItemHasContents, true);
         setSurface(nullptr);
         cursorImage->setCursor(cursor);
         setHotSpot(cursorImage->hotSpot());


### PR DESCRIPTION
1. Fix https://github.com/linuxdeepin/developer-center/issues/10684

2. Fix
```
wlroots: "[render/gles2/renderer.c:159] Created GL FBO for buffer 24x24"
ASSERT: "texture" in file /home/rewine/deepin-deb/qtdeclarative/src/quick/scenegraph/util/qsgdefaultimagenode.cpp, line 108

Thread 1 "tinywl-qtquick" received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0)
    at ./nptl/pthread_kill.c:44
44      ./nptl/pthread_kill.c: 没有那个文件或目录.
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0)
    at ./nptl/pthread_kill.c:44
#1  0x00007ffff4aa715f in __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  0x00007ffff4a59102 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007ffff4a424f2 in __GI_abort () at ./stdlib/abort.c:79
#4  0x00007ffff50b6528 in  () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#5  0x00007ffff50f1c60 in  () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#6  0x00007ffff50b6eb9 in qt_assert(char const*, char const*, int) () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#7  0x00007ffff50b6f16 in qt_assert_x(char const*, char const*, char const*, int) ()
    at /lib/x86_64-linux-gnu/libQt6Core.so.6
#8  0x00007ffff7067430 in QSGDefaultImageNode::setTexture(QSGTexture*) (this=0x5555568e72c0, texture=0x0)
    at /home/rewine/deepin-deb/qtdeclarative/src/quick/scenegraph/util/qsgdefaultimagenode.cpp:108
#9  0x00007ffff7c6a035 in Waylib::Server::WQuickCursor::updatePaintNode(QSGNode*, QQuickItem::UpdatePaintNodeData*) (this=0x5555564740b0, node=0x0) at /home/rewine/treeland.private/waylib/src/server/qtquick/wquickcursor.cpp:584
#10 0x00007ffff6f42d04 in QQuickWindowPrivate::updateDirtyNode(QQuickItem*)
    (this=0x555555faa470, item=0x5555564740b0)
    at /home/rewine/deepin-deb/qtdeclarative/src/quick/items/qquickwindow.cpp:2155
#11 0x00007ffff6f41988 in QQuickWindowPrivate::updateDirtyNodes() (this=0x555555faa470)
    at /home/rewine/deepin-deb/qtdeclarative/src/quick/items/qquickwindow.cpp:1897
#12 0x00007ffff6f3c7dc in QQuickWindowPrivate::syncSceneGraph() (this=0x555555faa470)
    at /home/rewine/deepin-deb/qtdeclarative/src/quick/items/qquickwindow.cpp:545
#13 0x00007ffff6e95cea in QQuickRenderControl::sync() (this=0x55555563cae0)
    at /home/rewine/deepin-deb/qtdeclarative/src/quick/items/qquickrendercontrol.cpp:378
#14 0x00007ffff7c2769a in Waylib::Server::WOutputRenderWindowPrivate::doRender(QList<Waylib::Server::OutputHelper*> const&, bool, bool) (this=0x555555faa470, outputs=..., forceRender=false, doCommit=true)                          
    at /home/rewine/treeland.private/waylib/src/server/qtquick/woutputrenderwindow.cpp:1456
#15 0x00007ffff7c3028d in Waylib::Server::WOutputRenderWindowPrivate::doRender() (this=0x555555faa470)
    at /home/rewine/treeland.private/waylib/src/server/qtquick/woutputrenderwindow.cpp:424
#16 0x00007ffff7c29517 in Waylib::Server::WOutputRenderWindow::event(QEvent*)
    (this=0x555555fabba0, event=0x5555568fc800)
    at /home/rewine/treeland.private/waylib/src/server/qtquick/woutputrenderwindow.cpp:1891
#17 0x00007ffff514e708 in QCoreApplication::notifyInternal2(QObject*, QEvent*) ()
    at /lib/x86_64-linux-gnu/libQt6Core.so.6
#18 0x00007ffff514e8fd in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) ()
    at /lib/x86_64-linux-gnu/libQt6Core.so.6
#19 0x00007ffff5342147 in  () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#20 0x00007ffff4513e0f in  () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#21 0x00007ffff4515e97 in  () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#22 0x00007ffff45164b0 in g_main_context_iteration () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#23 0x00007ffff533fef0 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) ()
    at /lib/x86_64-linux-gnu/libQt6Core.so.6
#24 0x00007ffff5158a4a in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) ()
    at /lib/x86_64-linux-gnu/libQt6Core.so.6
#25 0x00007ffff515218c in QCoreApplication::exec() () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#26 0x00005555555892d0 in main(int, char**) (argc=1, argv=0x7fffffffded8)
    at /home/rewine/treeland.private/waylib/examples/tinywl/main.cpp:827

```
