### PR TITLE
fix: nullptr in paintOrderItems

### DIFF
--- a/src/server/qtquick/woutputrenderwindow.cpp
+++ b/src/server/qtquick/woutputrenderwindow.cpp
@@ -1788,7 +1788,9 @@ QList<QPointer<QQuickItem>> WOutputRenderWindow::paintOrderItemList(QQuickItem *
     nodes.push(root);
     while (!nodes.isEmpty()){
         auto node = nodes.pop();
-        if (filter(node)) {
+        if (!node)
+            continue;
+        if (!filter || filter(node)) {
             result.append(node);
         }
         auto childItems = QQuickItemPrivate::get(node)->paintOrderChildItems();


### PR DESCRIPTION
Should check if node and filter is null or not.