### PR TITLE
fix: opposite scroll direction in internal items

### DIFF
--- a/src/server/kernel/wseat.cpp
+++ b/src/server/kernel/wseat.cpp
@@ -849,7 +849,7 @@ bool WSeat::sendEvent(WSurface *target, QObject *shellObject, QObject *eventObje
             d->doNotifyAxis(static_cast<wlr_axis_source>(we->wlrSource()),
                         orientation,
                         we->wlrDelta(),
-                        we->angleDelta().x()+we->angleDelta().y(), // one of them must be 0
+                        -(we->angleDelta().x()+we->angleDelta().y()), // one of them must be 0, restore to wayland direction here.
                         we->timestamp());
         } else {
             qWarning("An Wheel event was received that was not sent by wlroot and will be ignored");
@@ -1080,7 +1080,9 @@ void WSeat::notifyAxis(WCursor *cursor, WInputDevice *device, wlr_axis_source_t 
     const QPointF &global = cursor->position();
     const QPointF local = w ? global - QPointF(w->position()) : QPointF();
 
-    QPoint angleDelta = orientation == Qt::Horizontal ? QPoint(delta_discrete, 0) : QPoint(0, delta_discrete);
+    // Refer to https://github.com/qt/qtwayland/blob/774c0be247bd04362fc7713919ac151c44e34ced/src/client/qwaylandinputdevice.cpp#L1089
+    // The direction in Qt event is in the opposite direction of wayland one, generate a event identical to Qt's direction.
+    QPoint angleDelta = orientation == Qt::Horizontal ? QPoint(-delta_discrete, 0) : QPoint(0, -delta_discrete);
     WSeatWheelEvent e(source, delta, local, global, QPoint(), angleDelta, Qt::NoButton, d->keyModifiers,
                   Qt::NoScrollPhase, false, Qt::MouseEventNotSynthesized, qwDevice);
     e.setTimestamp(timestamp);


### PR DESCRIPTION
Should generate WSeatWheelEvent correctly for internal items. Use the opposite direction of wayland for Qt.

Refer-to: https://github.com/qt/qtwayland/blob/774c0be247bd04362fc7713919ac151c44e34ced/src/client/qwaylandinputdevice.cpp#L1089