### PR TITLE
fix the primaryoutput is empty

### DIFF
--- a/examples/tinywl/rootsurfacecontainer.cpp
+++ b/examples/tinywl/rootsurfacecontainer.cpp
@@ -117,6 +117,7 @@ void RootSurfaceContainer::removeOutput(Output *output)
         endMoveResize();
     }
 
+    m_outputLayout->remove(output->output());
     if (m_primaryOutput == output) {
         const auto outputs = m_outputLayout->outputs();
         if (!outputs.isEmpty()) {
@@ -136,8 +137,6 @@ void RootSurfaceContainer::removeOutput(Output *output)
         else
             Helper::instance()->setCursorPosition(m_primaryOutput->geometry().center());
     }
-
-    m_outputLayout->remove(output->output());
 }
 
 void RootSurfaceContainer::beginMoveResize(SurfaceWrapper *surface, Qt::Edges edges)


### PR DESCRIPTION
When the primary output is removed in multiple screens, if the first one of outputLayout->outputs happens to be the primary output, the primaryOutput is set to empty.