### PR TITLE
Fix popup crash when parent is layer surface

### DIFF
--- a/examples/tinywl/helper.cpp
+++ b/examples/tinywl/helper.cpp
@@ -186,7 +186,7 @@ void Helper::init()
 
     auto *xdgShell = m_server->attach<WXdgShell>();
     m_foreignToplevel = m_server->attach<WForeignToplevel>(xdgShell);
-    auto *layerShell = m_server->attach<WLayerShell>();
+    auto *layerShell = m_server->attach<WLayerShell>(xdgShell);
     auto *xdgOutputManager = m_server->attach<WXdgOutputManager>(m_surfaceContainer->outputLayout());
     m_windowMenu = engine->createWindowMenu(this);
 

--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732177097,
-        "narHash": "sha256-e5HtEtWwEEDEE0YyE/topJ+ny6zkUTw5GPTGFzpoARg=",
+        "lastModified": 1732273316,
+        "narHash": "sha256-eFRAGuOqcXFaL20pQYrPweF683xa+EweHgvoB92j0LM=",
         "owner": "vioken",
         "repo": "qwlroots",
-        "rev": "b9c6d5e59a1da42fe6c475b896eb7c1cb0d99c58",
+        "rev": "43871fedd02b9a5dce33c35e5b8b4f40e5ce469b",
         "type": "github"
       },
       "original": {

--- a/src/server/protocols/wlayershell.h
+++ b/src/server/protocols/wlayershell.h
@@ -11,6 +11,7 @@
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
+class WXdgShell;
 class WLayerSurface;
 class WLayerShellPrivate;
 class WAYLIB_SERVER_EXPORT WLayerShell: public WWrapObject, public WServerInterface
@@ -19,7 +20,7 @@ class WAYLIB_SERVER_EXPORT WLayerShell: public WWrapObject, public WServerInterf
     W_DECLARE_PRIVATE(WLayerShell)
 
 public:
-    explicit WLayerShell(QObject *parent = nullptr);
+    explicit WLayerShell(WXdgShell *xdgShell, QObject *parent = nullptr);
     void *create();
 
     QVector<WLayerSurface*> surfaceList() const;

--- a/src/server/protocols/wxdgshell.h
+++ b/src/server/protocols/wxdgshell.h
@@ -5,6 +5,8 @@
 
 #include <WServer>
 
+class wlr_xdg_popup;
+
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WXdgToplevelSurface;
@@ -25,6 +27,9 @@ Q_SIGNALS:
     void toplevelSurfaceRemoved(WXdgToplevelSurface *surface);
     void popupSurfaceAdded(WXdgPopupSurface *surface);
     void popupSurfaceRemoved(WXdgPopupSurface *surface);
+
+public:
+    void initializeNewXdgPopupSurface(wlr_xdg_popup *popup);
 
 protected:
     void create(WServer *server) override;


### PR DESCRIPTION
When layer_surface is an xdg_popup's parent, the popup should created via xdg_surface::get_popup with the parent set to NULL, and 'zwlr_layer_surface_v1::get_popup' must be invoked before committing the popup's initial state.

We should use parent's `notify_new_popup` to avoid get a popup with NULLparent