### PR TITLE
fix: layershell not shown on init

### DIFF
--- a/examples/tinywl/output.cpp
+++ b/examples/tinywl/output.cpp
@@ -17,6 +17,7 @@
 #include <wquicktextureproxy.h>
 
 #include <qwoutputlayout.h>
+#include <qwlayershellv1.h>
 
 #include <QQmlEngine>
 
@@ -231,6 +232,9 @@ void Output::layoutLayerSurface(SurfaceWrapper *surface)
 {
     WLayerSurface* layer = qobject_cast<WLayerSurface*>(surface->shellSurface());
     Q_ASSERT(layer);
+    if (!layer->handle()->handle()->initialized) {
+        return;
+    }
 
     auto validGeo = layer->exclusiveZone() == -1 ? this->rect() : validRect();
     validGeo = validGeo.marginsRemoved(QMargins(layer->leftMargin(),


### PR DESCRIPTION
The internal information of an uninitialized shell surface may not be correct. If configure it at this time, the client will receive an error message. For example, if the layershell surface has no anchor information, its size will be incorrect.

pms: BUG-288905