### PR TITLE
fix: crash when quickly resend focus

### DIFF
--- a/src/server/protocols/winputmethodhelper.h
+++ b/src/server/protocols/winputmethodhelper.h
@@ -59,7 +59,8 @@ private:
     void handleFocusedTICommitted();
     void handleIMCommitted();
     WTextInput *focusedTextInput() const;
-    void setFocusedTextInput(WTextInput *ti);
+    WTextInput *enabledTextInput() const;
+    void setEnabledTextInput(WTextInput *ti);
     WInputMethodV2 *inputMethod() const;
     void setInputMethod(WInputMethodV2 *im);
     QW_NAMESPACE::qw_input_method_keyboard_grab_v2 *activeKeyboardGrab() const;


### PR DESCRIPTION
Separate focused text input and enabled text input. Focused text input corresponds to sendEnter while enabled text input corresponds to enabled event.