### PR TITLE
Fix BackdropBlitter contents error

### DIFF
--- a/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/src/server/qtquick/private/wbufferrenderer.cpp
@@ -233,6 +233,11 @@ QSGRenderer *WBufferRenderer::currentRenderer() const
     return state.renderer;
 }
 
+qreal WBufferRenderer::currentDevicePixelRatio() const
+{
+    return state.devicePixelRatio;
+}
+
 const QMatrix4x4 &WBufferRenderer::currentWorldTransform() const
 {
     return state.worldTransform;

--- a/src/server/qtquick/private/wbufferrenderer_p.h
+++ b/src/server/qtquick/private/wbufferrenderer_p.h
@@ -68,6 +68,7 @@ public:
     void setClearColor(const QColor &clearColor);
 
     QSGRenderer *currentRenderer() const;
+    qreal currentDevicePixelRatio() const;
     const QMatrix4x4 &currentWorldTransform() const;
     QW_NAMESPACE::qw_buffer *currentBuffer() const;
     QW_NAMESPACE::qw_buffer *lastBuffer() const;

--- a/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -1093,7 +1093,7 @@ qreal WRenderBufferNode::effectiveDevicePixelRatio() const
     if (!sgRenderer || sgRenderer->renderTarget().rt != renderTarget())
         return window->effectiveDevicePixelRatio();
 
-    return sgRenderer->devicePixelRatio();
+    return renderer->currentDevicePixelRatio();
 }
 
 WRenderBufferNode::WRenderBufferNode(QQuickItem *item, QSGTexture *texture)


### PR DESCRIPTION
This bug from b9db116d60c1be4417c9871be44543d02bb6741e, on the two outputs if the first output's scale is 1.0 and the second output's scale is 1.5, on the first output, the size of texture from blitter is not equality to the BackdropBlitter's pixel size.