### PR TITLE
Fixed the crash when run vlc for the first time

### DIFF
--- a/src/server/protocols/wforeigntoplevelv1.cpp
+++ b/src/server/protocols/wforeigntoplevelv1.cpp
@@ -34,7 +34,7 @@ public:
     }
 
     void initSurface(WToplevelSurface *surface) {
-        auto handle = surfaces[surface].get();
+        auto handle = surfaces.at(surface).get();
         std::vector<QMetaObject::Connection> connection;
 
         connection.push_back(surface->safeConnect(&WToplevelSurface::titleChanged, surface, [handle, surface] {
@@ -71,8 +71,9 @@ public:
                 if (!surfaces.contains(p)) {
                     qCCritical(qLcWlrForeignToplevel) << "Xdg toplevel surface " << xdgSurface
                                                       << "has set parent surface, but foreign_toplevel_handle for parent surface not found!";
+                    return;
                 }
-                handle->set_parent(*surfaces[p]);
+                handle->set_parent(*surfaces.at(p));
             };
             connection.push_back(xdgSurface->safeConnect(&WXdgToplevelSurface::parentXdgSurfaceChanged, surface, updateSurfaceParent));
             updateSurfaceParent();
@@ -86,8 +87,9 @@ public:
                 if (!surfaces.contains(p)) {
                     qCCritical(qLcWlrForeignToplevel) << "X11 surface " << xwaylandSurface
                                                       << "has set parent surface, but foreign_toplevel_handle for parent surface not found!";
+                    return;
                 }
-                handle->set_parent(*surfaces[p]);
+                handle->set_parent(*surfaces.at(p));
             };
             connection.push_back(xwaylandSurface->safeConnect(&WXWaylandSurface::parentXWaylandSurfaceChanged, surface, updateSurfaceParent));
             updateSurfaceParent();
@@ -168,13 +170,13 @@ public:
 
     void surfaceOutputEnter(WToplevelSurface *surface, WOutput *output) {
         Q_ASSERT(surfaces.count(surface));
-        auto handle = surfaces[surface].get();
+        auto handle = surfaces.at(surface).get();
         handle->output_enter(output->nativeHandle());
     }
 
     void surfaceOutputLeave(WToplevelSurface *surface, WOutput *output) {
         Q_ASSERT(surfaces.count(surface));
-        auto handle = surfaces[surface].get();
+        auto handle = surfaces.at(surface).get();
         handle->output_leave(output->nativeHandle());
     }
 


### PR DESCRIPTION
```shell
Thread 1 "treeland" received signal SIGSEGV, Segmentation fault.
0x00007f8ac634ba16 in wlr_foreign_toplevel_handle_v1_set_parent (toplevel=0x0, parent=0x0) at ../types/wlr_foreign_toplevel_management_v1.c:477
477             if (parent == toplevel->parent) {
(gdb) bt
#0  0x00007f8ac634ba16 in wlr_foreign_toplevel_handle_v1_set_parent (toplevel=0x0, parent=0x0) at ../types/wlr_foreign_toplevel_management_v1.c:477
#1  0x00007f8ac6913abf in qw_foreign_toplevel_handle_v1::set_parent<decltype(nullptr)>(decltype(nullptr)&&) const (this=0x0)
    at /usr/include/qwlroots/qwforeigntoplevelhandlev1.h:49
#2  0x00007f8ac6911bdf in Waylib::Server::WForeignToplevelPrivate::initSurface(Waylib::Server::WToplevelSurface*)::{lambda()#8}::operator()() const
    (__closure=0x7ffdfc3eb480) at /home/v25/Documents/Code/waylib/src/server/protocols/wforeigntoplevelv1.cpp:83
#3  0x00007f8ac691252f in Waylib::Server::WForeignToplevelPrivate::initSurface (this=0x56058c3f6540, surface=0x56058eb66ed0)
    at /home/v25/Documents/Code/waylib/src/server/protocols/wforeigntoplevelv1.cpp:93
#4  0x00007f8ac6912e65 in Waylib::Server::WForeignToplevelPrivate::add (this=0x56058c3f6540, surface=0x56058eb66ed0)
    at /home/v25/Documents/Code/waylib/src/server/protocols/wforeigntoplevelv1.cpp:155
#5  0x00007f8ac6910fcd in Waylib::Server::WForeignToplevel::addSurface (this=0x56058c3b52b0, surface=0x56058eb66ed0)
    at /home/v25/Documents/Code/waylib/src/server/protocols/wforeigntoplevelv1.cpp:196
#6  0x00007f8ac6efeeb5 in Helper::onSurfaceWrapperAdded (this=0x56058c0ea310, wrapper=0x56058edf9b50)
    at /home/v25/Documents/Code/treeland.private/src/core/helper.cpp:607
#7  0x00007f8ac6f1e4e3 in QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<SurfaceWrapper*>, void, void (Helper::*)(SurfaceWrapper*)>::call(void (Helper::*)(SurfaceWrapper*), Helper*, void**)::{lambda()#1}::operator()() const (__closure=0x7ffdfc3eb8c0)
    at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:152
#8  0x00007f8ac6f1f9a0 in QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<SurfaceWrapper*>, void, void (Helper::*)(SurfaceWrapper*)>::call(void (Helper::*)(SurfaceWrapper*), Helper*, void**)::{lambda()#1}>(void**, QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<SurfaceWrapper*>, void, void (Helper::*)(SurfaceWrapper*)>::call(void (Helper::*)(SurfaceWrapper*), Helper*, void**)::{lambda()#1}&&)
    (args=0x7ffdfc3eba70, fn=...) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:65
#9  0x00007f8ac6f1e544 in QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<SurfaceWrapper*>, void, void (Helper::*)(SurfaceWrapper*)>::call
    (f=(void (Helper::*)(class Helper * const, class SurfaceWrapper *)) 0x7f8ac6efea46 <Helper::onSurfaceWrapperAdded(SurfaceWrapper*)>, o=0x56058c0ea310, arg=0x7ffdfc3eba70) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:151
#10 0x00007f8ac6f1c6c4 in QtPrivate::FunctionPointer<void (Helper::*)(SurfaceWrapper*)>::call<QtPrivate::List<SurfaceWrapper*>, void>
    (f=(void (Helper::*)(class Helper * const, class SurfaceWrapper *)) 0x7f8ac6efea46 <Helper::onSurfaceWrapperAdded(SurfaceWrapper*)>, o=0x56058c0ea310, arg=0x7ffdfc3eba70) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:199
#11 0x00007f8ac6f1a3e7 in QtPrivate::QCallableObject<void (Helper::*)(SurfaceWrapper*), QtPrivate::List<SurfaceWrapper*>, void>::impl
    (which=1, this_=0x56058c3e2f00, r=0x56058c0ea310, a=0x7ffdfc3eba70, ret=0x0) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:570
#12 0x00007f8ac53a596c in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#13 0x00007f8ac6eb2bbb in ShellHandler::surfaceWrapperAdded (this=0x56058c1755a0, _t1=0x56058edf9b50)
    at /home/v25/Documents/Code/treeland.private/builddir/src/core/treeland_core_autogen/EWIEGA46WW/moc_shellhandler.cpp:230
#14 0x00007f8ac6f374b3 in operator() (__closure=0x56058eb56560) at /home/v25/Documents/Code/treeland.private/src/core/shellhandler.cpp:237
#15 0x00007f8ac6f3b0d9 in operator() (__closure=0x7ffdfc3ebb60) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:141
#16 0x00007f8ac6f3b35e in QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, ShellHandler::onXWaylandSurfaceAdded(Waylib::Server::WXWaylandSurface*)::<lambda()> >::call(ShellHandler::onXWaylandSurfaceAdded(Waylib::Server::WXWaylandSurface*)::<lambda()>&, void**)::<lambda()> >(void **, struct {...} &&) (args=0x7ffdfc3ebc88, fn=...) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:65
#17 0x00007f8ac6f3b10f in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, ShellHandler::onXWaylandSurfaceAdded(Waylib::Server::WXWaylandSurface*)::<lambda()> >::call(struct {...} &, void **) (f=..., arg=0x7ffdfc3ebc88) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:140
#18 0x00007f8ac6f3abf7 in QtPrivate::FunctorCallable<ShellHandler::onXWaylandSurfaceAdded(Waylib::Server::WXWaylandSurface*)::<lambda()> >::call<QtPrivate::List<>, void>(struct {...} &, void *, void **) (f=..., arg=0x7ffdfc3ebc88) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:362
#19 0x00007f8ac6f3a87e in QtPrivate::QCallableObject<ShellHandler::onXWaylandSurfaceAdded(Waylib::Server::WXWaylandSurface*)::<lambda()>, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase *, QObject *, void **, bool *) (which=1, this_=0x56058eb56550, r=0x56058c1755a0, a=0x7ffdfc3ebc88, ret=0x0)
    at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:572
#20 0x00007f8ac53a596c in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#21 0x00007f8ac6978d0d in qw_xwayland_surface::notify_associate (this=0x56058d2cbe20)
    at /home/v25/Documents/Code/qwlroots/builddir/src/qwlroots_autogen/GZRP3O7STM/moc_qwxwaylandsurface.cpp:502
#22 0x00007f8ac6f0b804 in qw_signal_connector::callSlot0 (wl_listener=0x56058d2c7d38) at /usr/include/qwlroots/qwsignalconnector.h:144
#23 0x00007f8ac5fc0afc in wl_signal_emit_mutable () at /usr/bin/../lib/x86_64-linux-gnu/libwayland-server.so.0
#24 0x00007f8ac6382564 in xwayland_surface_associate (xwm=0x56058e78f440, xsurface=0x56058ecdb6e0, surface=0x56058edf7bc0) at ../xwayland/xwm.c:974
#25 0x00007f8ac6383016 in xwm_handle_surface_serial_message (xwm=0x56058e78f440, ev=0x56058ec1d4b0) at ../xwayland/xwm.c:1246
#26 0x00007f8ac6383a4b in xwm_handle_client_message (xwm=0x56058e78f440, ev=0x56058ec1d4b0) at ../xwayland/xwm.c:1547
#27 0x00007f8ac638415a in x11_event_handler (fd=68, mask=1, data=0x56058e78f440) at ../xwayland/xwm.c:1720
#28 0x00007f8ac5fc2c52 in wl_event_loop_dispatch () at /usr/bin/../lib/x86_64-linux-gnu/libwayland-server.so.0
#29 0x00007f8ac68047b6 in operator() (__closure=0x56058c3dc970) at /home/v25/Documents/Code/waylib/src/server/kernel/wserver.cpp:108
#30 0x00007f8ac680644f in operator() (__closure=0x7ffdfc3ec1c0) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:141
#31 0x00007f8ac6806500 in QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, Waylib::Server::WServerPrivate::init()::<lambda()> >::call(Waylib::Server::WServerPrivate::init()::<lambda()>&, void**)::<lambda()> >(void **, struct {...} &&)
    (args=0x7ffdfc3ec350, fn=...) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:65
--Type <RET> for more, q to quit, c to continue without paging--
#32 0x00007f8ac6806485 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, Waylib::Server::WServerPrivate::init()::<lambda()> >::call(struct {...} &, void **) (f=..., arg=0x7ffdfc3ec350) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:140
#33 0x00007f8ac68063f9 in QtPrivate::FunctorCallable<Waylib::Server::WServerPrivate::init()::<lambda()> >::call<QtPrivate::List<>, void>(struct {...} &, void *, void **) (f=..., arg=0x7ffdfc3ec350) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:362
#34 0x00007f8ac6806312 in QtPrivate::QCallableObject<Waylib::Server::WServerPrivate::init()::<lambda()>, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase *, QObject *, void **, bool *) (which=1, this_=0x56058c3dc960, r=0x56058cb0cad0, a=0x7ffdfc3ec350, ret=0x0)
    at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:572
#35 0x00007f8ac53a596c in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#36 0x00007f8ac53afe83 in QSocketNotifier::activated(QSocketDescriptor, QSocketNotifier::Type, QSocketNotifier::QPrivateSignal) () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#37 0x00007f8ac53affb3 in QSocketNotifier::event(QEvent*) () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#38 0x00007f8ac5359898 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#39 0x00007f8ac55554af in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#40 0x00007f8ac3400e0f in ??? () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#41 0x00007f8ac3402e97 in ??? () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#42 0x00007f8ac34034b0 in g_main_context_iteration () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#43 0x00007f8ac554cfd0 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#44 0x00007f8ac53625da in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#45 0x00007f8ac535c6c8 in QCoreApplication::exec() () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#46 0x0000560551abd66a in main (argc=3, argv=0x7ffdfc3ec9c8) at /home/v25/Documents/Code/treeland.private/src/main.cpp:46
(gdb) p parent
$1 = (struct wlr_foreign_toplevel_handle_v1 *) 0x0
(gdb) p toplevel
$2 = (struct wlr_foreign_toplevel_handle_v1 *) 0x0
(gdb) frame 2
#2  0x00007f8ac6911bdf in Waylib::Server::WForeignToplevelPrivate::initSurface(Waylib::Server::WToplevelSurface*)::{lambda()#8}::operator()() const (__closure=0x7ffdfc3eb480) at /home/v25/Documents/Code/waylib/src/server/protocols/wforeigntoplevelv1.cpp:83
83                          handle->set_parent(nullptr);
(gdb) p handle
$3 = (qw_foreign_toplevel_handle_v1 * const) 0x0
(gdb) 
```
