### PR TITLE
fix: before_destroy sequential problems

### DIFF
--- a/src/server/protocols/private/wtextinputv1.cpp
+++ b/src/server/protocols/private/wtextinputv1.cpp
@@ -249,9 +249,7 @@ void text_input_handle_activate(wl_client *client,
         if (text_input->focusedSurface())
             text_input->focusedSurface()->safeDisconnect(text_input);
         d->focusedSurface = wSurface;
-        wSurface->safeConnect(&qw_surface::before_destroy, text_input, [d, text_input]{
-            d->focusedSurface = nullptr;
-        });
+        wSurface->safeConnect(&WSurface::aboutToBeInvalidated, text_input, &WTextInputV1::sendLeave);
     }
     d->active = true;
     Q_EMIT text_input->activate();

--- a/src/server/protocols/winputmethodhelper.cpp
+++ b/src/server/protocols/winputmethodhelper.cpp
@@ -205,7 +205,7 @@ void WInputMethodHelper::handleNewIMV2(qw_input_method_v2 *imv2)
     // Once input method is online, try to resend enter to textInput
     resendKeyboardFocus();
     // For text input v1, when after sendEnter, enabled signal will be emitted
-    wimv2->safeConnect(&qw_input_method_v2::before_destroy, this, [this, wimv2]{
+    wimv2->safeConnect(&WInputMethodV2::aboutToBeInvalidated, this, [this, wimv2]{
         if (inputMethod() == wimv2) {
             setInputMethod(nullptr);
         }


### PR DESCRIPTION
Do not connect to before_destroy to do something except for deleting
wrap objects. Connect to aboutToBeInvalidated instead. Connect to
before_destroy might face multi-slot sequential problems. Wrap object
might be destroyed already(Safe connections will be disconnected then).
