### PR TITLE
fix: safeConnect instantiation error

### DIFF
--- a/src/server/kernel/wsurface.cpp
+++ b/src/server/kernel/wsurface.cpp
@@ -316,7 +316,7 @@ void WSurface::enterOutput(WOutput *output)
         return;
     wlr_surface_send_enter(d->nativeHandle(), output->handle()->handle());
 
-    output->safeConnect(&WOutput::destroyed, this, [d] {
+    connect(output, &WOutput::destroyed, this, [d] {
         d->updateOutputs();
     });
     output->safeConnect(&WOutput::scaleChanged, this, [d] {

--- a/src/server/protocols/wlayershell.cpp
+++ b/src/server/protocols/wlayershell.cpp
@@ -50,7 +50,7 @@ void WLayerShellPrivate::onNewSurface(qw_layer_surface_v1 *layerSurface)
     surface->safeConnect(&qw_layer_surface_v1::before_destroy, q, [this, layerSurface] {
         onSurfaceDestroy(layerSurface);
     });
-    QObject::connect(layerSurface, &qw_layer_surface_v1::notify_new_popup, q, [this] (wlr_xdg_popup *popup) {
+    surface->safeConnect(&qw_layer_surface_v1::notify_new_popup, q, [this] (wlr_xdg_popup *popup) {
         if (xdgShell)
             xdgShell->initializeNewXdgPopupSurface(popup);
         else

--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -1241,7 +1241,7 @@ WSurfaceItem *WSurfaceItemPrivate::ensureSubsurfaceItem(WSurface *subsurfaceSurf
     // contents.
     // AutoDestroy: Connect to this(parent)'s lambda since the autodestroy is managed by parent,
     // avoids disconnected with all slots on subsurfaceItem in subsurface's releaseResources
-    subsurfaceSurface->safeConnect(&WSurface::destroyed, q, [this,surfaceItem] {
+    QObject::connect(subsurfaceSurface, &WSurface::destroyed, q, [this,surfaceItem] {
         subsurfaces.removeOne(surfaceItem);
         surfaceItem->deleteLater();
     }, Qt::QueuedConnection);


### PR DESCRIPTION
SafeConnect does not work correctly when connecting to QObject's signal and qw_object_basic::before_destroy. Do not use it to connect to QObject::destroyed signal and forward to QObject::connect when connecting to before_destroy.