### PR TITLE
fix: toplevel lose fouse when click popup

### DIFF
--- a/src/server/protocols/wxdgpopupsurface.cpp
+++ b/src/server/protocols/wxdgpopupsurface.cpp
@@ -88,8 +88,8 @@ bool WXdgPopupSurface::hasCapability(Capability cap) const
     switch (cap) {
         using enum Capability;
     case Resize:
-    case Focus:
         return true;
+    case Focus:
     case Activate:
     case Maximized:
     case FullScreen:


### PR DESCRIPTION
When a popup appears or is clicked we should give focus to its parent. If the popup gets focus independently,  it will not be give focus to the parent after closing.