### PR TITLE
fix: wrong z order of render buffer blitter

### DIFF
--- a/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -516,10 +516,13 @@ public:
     }
 
     RenderingFlags flags() const override {
+        // FIXME: shoule we support DepthAwareRendering?
+        // When enable DepthAwareRendering, render buffer node may have a wrong order.
+        // Disable DepthAwareRendering here.
         if (Q_UNLIKELY(!contentNode))
-            return BoundedRectRendering | DepthAwareRendering;
+            return BoundedRectRendering;
 
-        return DepthAwareRendering;
+        return {};
     }
 
     void releaseResources() override {


### PR DESCRIPTION
Disable DepthAwareRendering to ensure the uniform render order as element order.