### PR TITLE
fix: texture from surface buffer failed

### DIFF
--- a/src/server/kernel/wsurface.cpp
+++ b/src/server/kernel/wsurface.cpp
@@ -116,18 +116,9 @@ void WSurfacePrivate::updateOutputs()
 
 void WSurfacePrivate::setBuffer(qw_buffer *newBuffer)
 {
-    if (buffer) {
-        if (auto clientBuffer = qw_client_buffer::get(*buffer)) {
-            Q_ASSERT(clientBuffer->handle()->n_ignore_locks > 0);
-            clientBuffer->handle()->n_ignore_locks--;
-        }
-    }
-
     if (newBuffer) {
-        if (auto clientBuffer = qw_client_buffer::get(*newBuffer)) {
-            clientBuffer->handle()->n_ignore_locks++;
-        }
-
+        auto clientBuffer = qw_client_buffer::get(*newBuffer);
+        auto sourceBuffer = clientBuffer ? qw_buffer::from(clientBuffer->handle()->source) : newBuffer;
         newBuffer->lock();
         buffer.reset(newBuffer);
     } else {


### PR DESCRIPTION
Use client buffer's source as surface buffer. Client buffer is not complete, and might fail to get texture when the source buffer is a shm buffer.