### PR TITLE
Specify the debhelper compat level exactly once

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libdevel
 Priority: optional
 Maintainer: JiDe Zhang <zhangjide@deepin.org>
 Build-Depends: cmake,
-               debhelper-compat (= 13),
+               debhelper (>= 9.0.0),
                libpixman-1-dev,
                libwlroots-0.18-dev,
                libxcb-ewmh-dev,


### PR DESCRIPTION
Fix error: debhelper compat level specified both in debian/compat and in debian/control

https://build.deepin.com/build/deepin:CI:deepin-community:waylib:PR-29/deepin_develop/aarch64/waylib/_log