### PR TITLE
fix: use WWrapPointer instead of QPointer

### DIFF
--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -10,6 +10,7 @@
 #include "woutputviewport.h"
 #include "wsgtextureprovider.h"
 #include "woutputrenderwindow.h"
+#include "wwrappointer.h"
 
 #include <qwcompositor.h>
 #include <qwsubcompositor.h>
@@ -270,7 +271,7 @@ public:
     }
 
     W_DECLARE_PUBLIC(WSurfaceItemContent)
-    QPointer<WSurface> surface;
+    WWrapPointer<WSurface> surface;
     QRectF bufferSourceBox;
     QPoint bufferOffset;
     qreal devicePixelRatio = 1.0;


### PR DESCRIPTION
```
#0  0x00007f5e8f8d42f0 in Waylib::Server::WSurfaceItemContent::bufferOffset() const () at /usr/bin/../lib/x86_64-linux-gnu/libwaylibserver.so.0
#1  0x00007f5e8f906608 in QtPrivate::QCallableObject<Waylib::Server::WQuickCursorPrivate::setSurface(Waylib::Server::WSurface*)::{lambda()#1}, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) () at /usr/bin/../lib/x86_64-linux-gnu/libwaylibserver.so.0
#2  0x00007f5e8f24096c in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#3  0x00007f5e8f8dc128 in Waylib::Server::WSurfaceItemContentPrivate::updateSurfaceState() () at /usr/bin/../lib/x86_64-linux-gnu/libwaylibserver.so.0
#4  0x00007f5e8f24096c in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#5  0x00007f5e8cfc7afc in wl_signal_emit_mutable () at /usr/bin/../lib/x86_64-linux-gnu/libwayland-server.so.0
#6  0x00007f5e8f695d1d in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libwlroots-0.18.so
#7  0x00007f5e8bbc701a in ??? () at /lib/x86_64-linux-gnu/libffi.so.8
#8  0x00007f5e8bbc64be in ??? () at /lib/x86_64-linux-gnu/libffi.so.8
#9  0x00007f5e8bbc6bad in ffi_call () at /lib/x86_64-linux-gnu/libffi.so.8
#10 0x00007f5e8cfcbf46 in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libwayland-server.so.0
#11 0x00007f5e8cfc6c9a in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libwayland-server.so.0
#12 0x00007f5e8cfc9c52 in wl_event_loop_dispatch () at /usr/bin/../lib/x86_64-linux-gnu/libwayland-server.so.0
#13 0x00007f5e8f8bc4e0 in QtPrivate::QCallableObject<Waylib::Server::WServerPrivate::init()::{lambda()#1}, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) () at /usr/bin/../lib/x86_64-linux-gnu/libwaylibserver.so.0
#14 0x00007f5e8f24096c in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#15 0x00007f5e8f3e7fa3 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#16 0x00007f5e8f1fd5da in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#17 0x00007f5e8f1f76c8 in QCoreApplication::exec() () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6
#18 0x000055ffbcade49d in main ()
```
