### PR TITLE
Fix get null handle in a valid qwobject

### DIFF
--- a/src/server/kernel/wglobal.cpp
+++ b/src/server/kernel/wglobal.cpp
@@ -202,6 +202,9 @@ QW_NAMESPACE::qw_object_basic *WWrapObject::handle() const
 bool WWrapObject::isInvalidated() const
 {
     W_DC(WWrapObject);
+
+    Q_ASSERT_X(d->invalidated || handle() != nullptr, Q_FUNC_INFO, "WWrapObject not invalidate in time");
+
     return d->invalidated;
 }
 

--- a/src/server/protocols/wxwaylandsurface.cpp
+++ b/src/server/protocols/wxwaylandsurface.cpp
@@ -63,9 +63,14 @@ public:
 
 void WXWaylandSurfacePrivate::instantRelease()
 {
+    W_Q(WXWaylandSurface);
     handle()->set_data(nullptr, nullptr);
-    if (surface)
-        surface->removeAttachedData<WXWaylandSurface>();
+    handle()->disconnect(q);
+
+    if (!surface)
+        return;
+    surface->safeDeleteLater();
+    surface = nullptr;
 }
 
 void WXWaylandSurfacePrivate::init()

--- a/src/server/qtquick/private/wsurfaceitem_p.h
+++ b/src/server/qtquick/private/wsurfaceitem_p.h
@@ -64,7 +64,7 @@ public:
     }
 
     Q_DECLARE_PUBLIC(WSurfaceItem)
-    WWrapPointer<WSurface> surface;
+    WSurface *surface = nullptr;
     WWrapPointer<WToplevelSurface> shellSurface;
     std::unique_ptr<SurfaceState> surfaceState;
     QQuickItem *contentContainer = nullptr;

--- a/src/server/qtquick/private/wsurfaceitem_p.h
+++ b/src/server/qtquick/private/wsurfaceitem_p.h
@@ -5,6 +5,7 @@
 
 #include "wsurfaceitem.h"
 #include "wsurface.h"
+#include "wwrappointer.h"
 
 #include <QQuickWindow>
 #include <QSGImageNode>
@@ -63,8 +64,8 @@ public:
     }
 
     Q_DECLARE_PUBLIC(WSurfaceItem)
-    QPointer<WSurface> surface;
-    QPointer<WToplevelSurface> shellSurface;
+    WWrapPointer<WSurface> surface;
+    WWrapPointer<WToplevelSurface> shellSurface;
     std::unique_ptr<SurfaceState> surfaceState;
     QQuickItem *contentContainer = nullptr;
     QQmlComponent *delegate = nullptr;

--- a/src/server/qtquick/wsurfaceitem.cpp
+++ b/src/server/qtquick/wsurfaceitem.cpp
@@ -271,7 +271,7 @@ public:
     }
 
     W_DECLARE_PUBLIC(WSurfaceItemContent)
-    WWrapPointer<WSurface> surface;
+    WSurface *surface = nullptr;
     QRectF bufferSourceBox;
     QPoint bufferOffset;
     qreal devicePixelRatio = 1.0;
@@ -592,7 +592,7 @@ WSurfaceItem *WSurfaceItem::fromFocusObject(QObject *focusObject)
 WSurface *WSurfaceItem::surface() const
 {
     Q_D(const WSurfaceItem);
-    return d->surface.get();
+    return d->surface;
 }
 
 void WSurfaceItem::setSurface(WSurface *surface)
@@ -900,6 +900,7 @@ void WSurfaceItem::releaseResources()
 
     if (d->surface) {
         d->surface->safeDisconnect(this);
+        d->surface = nullptr;
     }
 
     if (!d->surfaceFlags.testFlag(DontCacheLastBuffer)) {
@@ -936,7 +937,7 @@ bool WSurfaceItem::sendEvent(QInputEvent *event)
     if (!d->surface)
         return false;
 
-    return WSeat::sendEvent(d->surface.get(), this, d->eventItem, event);
+    return WSeat::sendEvent(d->surface, this, d->eventItem, event);
 }
 
 bool WSurfaceItem::doResizeSurface(const QSize &newSize)
@@ -1220,7 +1221,7 @@ WSurfaceItem *WSurfaceItemPrivate::ensureSubsurfaceItem(WSurface *subsurfaceSurf
 {
     for (int i = 0; i < subsurfaces.count(); ++i) {
         auto surfaceItem = subsurfaces.at(i);
-        WSurface *surface = surfaceItem->d_func()->surface.get();
+        WSurface *surface = surfaceItem->d_func()->surface;
 
         if (surface && surface == subsurfaceSurface) {
             if (surfaceItem->parent() == parent) {


### PR DESCRIPTION
Fix null pointer access issue encountered in EventItem::contains,

When WXWaylandSurface calls safeDeleteLater to destroy, WSurface should invalidated in time