### PR TITLE
fix: compatibility with Qt 6.9+

### DIFF
--- a/.github/workflows/archlinux-build-wlroots-18.yaml
+++ b/.github/workflows/archlinux-build-wlroots-18.yaml
@@ -21,7 +21,7 @@ jobs:
           pacman --noconfirm --noprogressbar -Syu
       - name: Install dep
         run: |
-          pacman -Syu --noconfirm --noprogressbar base-devel qt6-base qt6-declarative cmake pkgconfig pixman wlroots wayland-protocols wlr-protocols git
+          pacman -Syu --noconfirm --noprogressbar base-devel qt6-base qt6-declarative cmake pkgconfig pixman vulkan-headers wlroots wayland-protocols wlr-protocols git
           pacman -Syu --noconfirm --noprogressbar clang ninja make
           pacman -Syu --noconfirm --noprogressbar fakeroot meson sudo
       - uses: actions/checkout@v4

--- a/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/src/server/platformplugin/qwlrootsintegration.cpp
@@ -21,7 +21,13 @@
 #include <QGuiApplication>
 
 #include <private/qgenericunixfontdatabase_p.h>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+#include <private/qdesktopunixservices_p.h>
+#else
 #include <private/qgenericunixservices_p.h>
+#endif
+
 #include <private/qgenericunixeventdispatcher_p.h>
 #include <private/qhighdpiscaling_p.h>
 #if QT_CONFIG(vulkan)
@@ -237,7 +243,11 @@ QInputDevice *QWlrootsIntegration::getInputDeviceFrom(WInputDevice *device)
 void QWlrootsIntegration::initialize()
 {
     if (isMaster()) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+        m_services.reset(new QDesktopUnixServices);
+#else
         m_services.reset(new QGenericUnixServices);
+#endif
     }
 
     if (m_onInitialized)

--- a/src/server/qtquick/wqmlcreator.cpp
+++ b/src/server/qtquick/wqmlcreator.cpp
@@ -206,7 +206,7 @@ void WQmlCreatorComponent::create(QSharedPointer<WQmlCreatorDelegateData> data)
 
     auto d = QQmlComponentPrivate::get(m_delegate);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
     if (d->m_state.isCompletePending()) {
 #else
     if (d->state.isCompletePending()) {
@@ -228,7 +228,7 @@ void WQmlCreatorComponent::create(QSharedPointer<WQmlCreatorDelegateData> data, 
 {
     auto d = QQmlComponentPrivate::get(m_delegate);
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
     Q_ASSERT(!d->m_state.isCompletePending());
 #elif QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     Q_ASSERT(!d->state.isCompletePending());
@@ -281,7 +281,7 @@ void WQmlCreatorComponent::create(QSharedPointer<WQmlCreatorDelegateData> data, 
         notifyCreatorObjectAdded(creator(), data->object, initialProperties);
     } else {
         qWarning() << "WQmlCreatorComponent::create failed" << "parent=" << parent << "initialProperties=" << tmp;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
         for (auto e: d->m_state.errors)
 #else
         for (auto e: d->state.errors)


### PR DESCRIPTION
Qt renamed QGenericUnixServices on 6.9+:
https://github.com/qt/qtbase/commit/3e29267df0e2f332290caad69e5bd5cfd61cf3da

The fix for
https://github.com/qt/qtdeclarative/commit/2f35c7036e468d97ace2a5b3987674a30d29d532
wasn't cherry-picked into 6.9.0. Let's change it to target 6.10.0 for
now.

Also fix CI for Arch Linux.