### PR TITLE
fix: Check virtual device for QInputEvent

### DIFF
--- a/src/server/kernel/wseat.cpp
+++ b/src/server/kernel/wseat.cpp
@@ -667,6 +667,25 @@ WSeat *WSeat::fromHandle(const qw_seat *handle)
     return handle->get_data<WSeat>();
 }
 
+// Some event filter related functions needs to get WSeat from QInputEvent,
+// but the input event may come with a virtual device (e.g. created after a TTY
+// switch by an intenal mechanism, like QHoverEvent). Thus we needs a special
+// guarded getter.
+
+// @return A pointer to WSeat if the event is valid, nullptr if not.
+WSeat *WSeat::fromInputEvent(QInputEvent *event) {
+    auto qtDevice = event->device();
+    if (qtDevice->seatName().isEmpty()) {
+        return nullptr;
+    } else {
+        auto device = WInputDevice::from(qtDevice);
+        Q_ASSERT(device);
+        auto seat = device->seat();
+        Q_ASSERT(seat);
+        return seat;
+    }
+}
+
 qw_seat *WSeat::handle() const
 {
     return d_func()->handle();

--- a/src/server/kernel/wseat.h
+++ b/src/server/kernel/wseat.h
@@ -69,6 +69,7 @@ public:
     WSeat(const QString &name = QStringLiteral("seat0"));
 
     static WSeat *fromHandle(const QW_NAMESPACE::qw_seat *handle);
+    static WSeat *fromInputEvent(QInputEvent *event);
     QW_NAMESPACE::qw_seat *handle() const;
     wlr_seat *nativeHandle() const;
 

--- a/src/server/platformplugin/qwlrootswindow.cpp
+++ b/src/server/platformplugin/qwlrootswindow.cpp
@@ -132,11 +132,10 @@ bool QWlrootsRenderWindow::beforeDisposeEventFilter(QEvent *event)
 {
     if (event->isInputEvent()) {
         auto ie = static_cast<QInputEvent*>(event);
-        auto device = WInputDevice::from(ie->device());
-        Q_ASSERT(device);
-        Q_ASSERT(device->seat());
-        lastActiveCursor = device->seat()->cursor();
-        return device->seat()->filterEventBeforeDisposeStage(window(), ie);
+        auto seat = WSeat::fromInputEvent(ie);
+        if (!seat) return true;
+        lastActiveCursor = seat->cursor();
+        return seat->filterEventBeforeDisposeStage(window(), ie);
     }
 
     return false;
@@ -146,10 +145,10 @@ bool QWlrootsRenderWindow::afterDisposeEventFilter(QEvent *event)
 {
     if (event->isInputEvent()) {
         auto ie = static_cast<QInputEvent*>(event);
-        auto device = WInputDevice::from(ie->device());
-        Q_ASSERT(device);
-        lastActiveCursor = device->seat()->cursor();
-        return device->seat()->filterEventAfterDisposeStage(window(), ie);
+        auto seat = WSeat::fromInputEvent(ie);
+        if (!seat) return true;
+        lastActiveCursor = seat->cursor();
+        return seat->filterEventAfterDisposeStage(window(), ie);
     }
 
     return false;

--- a/src/server/qtquick/woutputrenderwindow.cpp
+++ b/src/server/qtquick/woutputrenderwindow.cpp
@@ -1971,10 +1971,9 @@ bool WOutputRenderWindow::eventFilter(QObject *watched, QEvent *event)
 {
     if (event->isInputEvent() && watched->isQuickItemType()) {
         auto ie = static_cast<QInputEvent*>(event);
-        auto device = WInputDevice::from(ie->device());
-        Q_ASSERT(device);
-        Q_ASSERT(device->seat());
-        if (device->seat()->filterEventBeforeDisposeStage(qobject_cast<QQuickItem*>(watched), ie))
+        auto seat = WSeat::fromInputEvent(ie);
+        if (!seat) return true;
+        if (seat->filterEventBeforeDisposeStage(qobject_cast<QQuickItem*>(watched), ie))
             return true;
     }
 


### PR DESCRIPTION
Qt will create virtual device for QInputEvent when no physical device available (e.g. switched to another VT), which will leads to a failed assertion and make treeland crash. This commit applies a special guarded getter for such case.

check from linuxdeepin/treeland/pull/466